### PR TITLE
PORT-916: Update default RTI.rid file to make defaults stand out more and be more user-friendly

### DIFF
--- a/codebase/resources/dist/RTI.rid
+++ b/codebase/resources/dist/RTI.rid
@@ -10,93 +10,39 @@
 # RTI_RID_FILE environment variable to point at wherever it is located.
 #
 
-# ================================
-# 1. General Options
-# ================================
-
-# (1.1) Portico Plugin Path
-#        This is a path that should be searched for Portico plugins. The format is a ";" separated
-#        list of locations for windows, or a ":" separated list for *nix. The default value is empty.
-#        (NOTE) Two locations are *ALWAYS* searched: ./plugins and $RTI_HOME/plugins
-#
-# portico.pluginpath = /opt/portico/plugins
-
-# (1.2) Management Object Model
-#        This controls whether or not the MOM is enabled. By default it is turned on, but if you
-#        don't want it you can turn it off. Valid values are "enabled" and "disabled"
-#
-# portico.mom = enabled
-
-# (1.3) Save/Restore Data Files Directory
-#        This specifies the path to the directory where federate save/restore data files are stored.
-#        By default, this is the "savedata" directory relative to the directory that the federate
-#        was launched from. Any valid operating system path can be specified, as long as it is
-#        writeable by the operating system user under which the federate is executing
-#
-# portico.saveDirectory = ./savedata
-
-# (1.4) Unsupported Methods Throw Exceptions
-#        By default, if a user attempts to call a method on the RTI that is currently not supported
-#        by Portico, an RTIinternalError is thrown outlining that situation. This can cause some
-#        federates to crash if they are not expecting it or checking for it. If you set this value
-#        to false, no exception will be thrown and only a message will be logged.
-#
-# portico.unsupportedExceptions = true
-
-# (1.5) Object Names Negotiated With Federation
-#        When registering an object with a specific name, to ensure that name is unique, the
-#        federate much negotiate with the rest of the federation. This incurs a performance hit.
-#        By default, this negotiation is turned off. If you have problems with conflicting names,
-#        set this property to true. In the default mode (negotiation disabled) the RTI is not
-#        totally standards compliant, and conflicts can occur if federates try to register objects
-#        with the same name at the same time (if the requests are sufficiently spaced out in time,
-#        this problem shouldn't occur).
-#
-# portico.object.negotiateNames = false
-
-# (1.6) Unique Federate Names
-#        By default, Portico, like other RTIs, will ensure that all federates in a federation have
-#        unique names. However, in some situations this is not desirable (like running Portico with
-#        JSAF or VBS2). In this case, you can turn the unique name checking to false. When you do
-#        this, what happens is that when Portico sees a name conflict, rather than throwing an
-#        exception it will change the requested name from "name" to "name (handle)" thus making it
-#        unique. Default is true, set to false to turn unique name checking off.
-#
-# portico.uniqueFederateNames = true
-
 # ===================================
-# 2. General Portico Logging Options
+# 1. General Portico Logging Options
 # ===================================
-# (NOTE) Some components (such as the JGroups comms binding) have their own logging settings. See
-#        the options for those components for those properties.
+# (NOTE) Some sub-components have their own log settings. See the sections relaing to them for
+#        those particular properties.
 
-# (2.1) Portico Log Level
-#        Specify the level that Portico will log at. Valid values are: TRACE, DEBUG, INFO, WARN,
-#        ERROR, FATAL, OFF. The default value is "WARN".
-#
-portico.loglevel = INFO
-
-# (2.2) Portico Container Log Level
-#        Specify the log level that Portico will use for its infrastructure elements (like the
-#        messaging framework, configuration, etc...). By default, this logger is disabled. 
-#        Generally speaking, this should not need to be changed as most runtime activity is
-#        logged through the general protico logger (see 2.1)
-#
-# portico.container.loglevel = TRACE
-
-# (2.3) Portico Log Directory
-#        Specify the directory to put the Portico log-files into. This defaults to "logs"
+# (1.1) Portico Log Directory
+#        Specify the directory to put the Portico log-files into. This defaults to "logs" and
+#        if a relative path is used, it will be releative to the location of the process that
+#        executed Portico
 #
 # portico.logdir = logs
 
-# (2.4) Print FOM when federate Joins
+# (1.2) Portico Log Level
+#        Specify the level that Portico will log at. Valid values are: TRACE, DEBUG, INFO, WARN,
+#        ERROR, FATAL, OFF. The default value is "WARN".
+#
+# portico.loglevel = INFO
+
+# (1.3) Portico Container Log Level
+#        Specify the log level that Portico will use for its infrastructure elements (like the
+#        messaging framework, configuration, etc...). By default, this logger is disabled. 
+#
+# portico.container.loglevel = OFF
+
+# (1.4) Print FOM when federate Joins
 #        When a federate joins a federation, Portico can pretty-print the FOM data of that
 #        federation. If this is enabled, the FOM is logged to the INFO level (so make sure you
 #        have logging turned up high enough). By default this is disabled.
 #
 # portico.fom.print = disabled
 
-# (2.5) Logging by Handle/Name
+# (1.5) Logging by Handle/Name
 #        Making sense of log files can be difficult. To help make sense of this data, various bits
 #        of HLA information can be logged by their HLA handle or their name. For example, an HLA
 #        object class can be logged by its handle, or by its name.
@@ -121,8 +67,94 @@ portico.loglevel = INFO
 # portico.logWithHandles=objectClass,attributeClass,interactionClass,parameterClass,space,dimension
 # portico.logWithNames=objectInstance,federate
 
+
+# ================================
+# 2. HLA Related RTI Properties
+# ================================
+# These settings relate to how the RTI works with regard to HLA operations
+
+# (2.1) Management Object Model
+#        This controls whether or not the MOM is enabled. By default it is turned on, but if you
+#        don't want it you can turn it off. Valid values are "enabled" and "disabled"
+#
+# portico.mom = enabled
+
+# (2.2) Save/Restore Data Files Directory
+#        This specifies the path to the directory where federate save/restore data files are stored.
+#        By default, this is the "savedata" directory relative to the directory that the federate
+#        was launched from. Any valid operating system path can be specified, as long as it is
+#        writeable by the operating system user under which the federate is executing
+#
+# portico.saveDirectory = ./savedata
+
+# (2.3) Unsupported Methods Throw Exceptions
+#        By default, if a user attempts to call a method on the RTI that is currently not supported
+#        by Portico, an RTIinternalError is thrown outlining that situation. This can cause some
+#        federates to crash if they are not expecting it or checking for it. If you set this value
+#        to false, no exception will be thrown and only a message will be logged.
+#
+# portico.unsupportedExceptions = true
+
+# (2.4) Object Names Negotiated With Federation
+#        When registering an object with a specific name, to ensure that name is unique, the
+#        federate much negotiate with the rest of the federation. This incurs a performance hit.
+#        By default, this negotiation is turned off. If you have problems with conflicting names,
+#        set this property to true. In the default mode (negotiation disabled) the RTI is not
+#        totally standards compliant, and conflicts can occur if federates try to register objects
+#        with the same name at the same time (if the requests are sufficiently spaced out in time,
+#        this problem shouldn't occur).
+#
+# portico.object.negotiateNames = false
+
+# (2.5) Unique Federate Names
+#        By default, Portico, like other RTIs, will ensure that all federates in a federation have
+#        unique names. However, in some situations this is not desirable (like running Portico with
+#        JSAF or VBS2). In this case, you can turn the unique name checking to false. When you do
+#        this, what happens is that when Portico sees a name conflict, rather than throwing an
+#        exception it will change the requested name from "name" to "name (handle)" thus making it
+#        unique. Default is true, set to false to turn unique name checking off.
+#
+# portico.uniqueFederateNames = true
+
+
+# ================================
+# 3. Advanced Options
+# ================================
+# These really shouldn't be changed unless you really know what you want
+
+# (3.1) Portico Plugin Path
+#        This is a path that should be searched for Portico plugins. The format is a ";" separated
+#        list of locations for windows, or a ":" separated list for *nix. The default value is empty.
+#        (NOTE) Two locations are *ALWAYS* searched: ./plugins and $RTI_HOME/plugins
+#
+# portico.pluginpath = /opt/portico/plugins
+
+# (3.2) Portico Communications Binding
+#        This defines the communications binding Portico uses to talk to the federation. Two
+#        implementations are provided with Portico: "jgroups" (default) and "jvm". If you have
+#        a different binding, you can specify the fully-qualified name of the class that implements
+#        IConnection (e.g. an alternate way to specify the default JGroups communications binding
+#        would be "org.portico.bindings.jgroups.LrcConnection")
+#        DEFAULT = jgroups
+#
+# portico.connection = jgroups
+
+# (3.3) LRC Tick Timeout
+#        When a federate calls tick() and there is no work to do, the LRC will wait for a period of
+#        time to allow work to arrive before it returns. This is designed to avoid a busy-looping
+#        situation where people are calling tick in a loop while waiting for some event.
+#
+#        The period of time the LRC will wait is specified by this value (in *MILLISECONDS*).
+#        DEFAULT = 5
+#
+#        (NOTE) This does not apply to the tick(min,max) call (in that case, the LRC will wait
+#               for at most "min" seconds for work to arrive).
+#
+# portico.lrc.tt = 5
+
+
 # =========================================
-# 3. JGroups Communication Binding Options
+# 4. JGroups Network Binding Options
 # =========================================
 # The JGroups XML configuration is contained within the jar file at the location
 # "etc/jgroups-udp.xml". If you want to replace that configuration wholesale, you can put an
@@ -130,7 +162,7 @@ portico.loglevel = INFO
 # of the one in the jar-file. Alternatively, you can just set these properties to control some
 # of the more prominent properties as it relates to Portico.
 
-# (3.1) JGroups Binding Log Level
+# (4.1) JGroups Binding Log Level
 #        The log level used by the internal JGroups logger. By default this is turned off, but if
 #        you want to see more information about what is happening at a network level, you can lower
 #        the threshold for this level (down to something like DEBUG or even TRACE). Note that this
@@ -138,7 +170,7 @@ portico.loglevel = INFO
 #        DEFAULT: OFF
 # portico.jgroups.loglevel = OFF
 
-# (3.2) JGroups Response Timeout
+# (4.2) JGroups Response Timeout
 #        Certain operations Portico uses wait for a specific amount of time for a response. The
 #        length of time a JGroups binding will wait for is specified by this property (in
 #        milliseconds). If you are having reliability problems, try making this value larger, but
@@ -148,25 +180,25 @@ portico.loglevel = INFO
 #
 # portico.jgroups.timeout = 1000
 
-# (3.3) JGroups UDP Address
+# (4.3) JGroups UDP Address
 #        The UDP address the JGroups binding will communicate on.
 #        DEFAULT: 228.10.10.10
 #
 # portico.jgroups.udp.address = 228.10.10.10 
 
-# (3.4) JGroups UDP Port
+# (4.4) JGroups UDP Port
 #        The UDP port the JGroups binding will communicate on.
 #        DEFAULT: 20913
 #
 # portico.jgroups.udp.port = 20913
 
-# (3.5) JGroups Bind Address
+# (4.5) JGroups Bind Address
 #        The address/NIC JGroups should use. Try setting this to your desired NIC if setting
 #        the send/receive interfaces don't work.
 #
 # portico.jgroups.udp.bindAddress = 
 
-# (3.6) JGroup UDP Receive Interfaces
+# (4.6) JGroup UDP Receive Interfaces
 #        The interfaces/addresses JGroups will listen on for incoming multicast packets. This
 #        should be a comma-separated list of IP-addresses or interface names,
 #        e.g. "192.168.0.10,eth1,127.0.0.1". Default will pick the first configured,
@@ -174,7 +206,7 @@ portico.loglevel = INFO
 #
 # portico.jgroups.udp.receiveInterfaces = 
 
-# (3.7) JGroup UDP Send Interfaces
+# (4.7) JGroup UDP Send Interfaces
 #        The interfaces/addresses JGroups will send multicast packets. This should be a
 #        comma-separated list of IP-addresses or interface names, e.g. "192.168.0.10,eth1,127.0.0.1"
 #        Default will pick the first configured, connected interface.
@@ -182,20 +214,20 @@ portico.loglevel = INFO
 # portico.jgroups.udp.sendInterfaces = 
 
 
-# (3.8) JGroups UDP Receive Buffer Size
+# (4.8) JGroups UDP Receive Buffer Size
 #        The size of the buffer that incoming messages are stored in before they're passed in to
 #        the LRC. If you find that you are sending messages that are quite large or quite small,
 #        you may want to adjust this value appropriately. Default is quite large (about 24mb).
 #
 # portico.jgroups.udp.receiveBuffer = 25000000
 
-# (3.9) JGroups UDP Send Buffer Size
+# (4.9) JGroups UDP Send Buffer Size
 #        The size of the buffer that messages are put in before they are sent out. Don't modify
 #        this unless you know what you're doing. 640k is enough for everything (ZING!)
 #
 # portico.jgroups.udp.sendBuffer = 640000
 
-# (3.10) JGroups Bundling Support
+# (4.10) JGroups Bundling Support
 #         If you are sending lots of smaller messages, higher overall throughput can be obtained by
 #         bundling them together into a fewer number of larger messages. However, doing so comes at
 #         the cost of latency. Messages will be stored up until either a timeout period is reached,
@@ -204,7 +236,7 @@ portico.loglevel = INFO
 #
 # portico.jgroups.bundling = true
 
-# (3.11) JGroups Bundling Max Size
+# (4.11) JGroups Bundling Max Size
 #         If bundling is enabled, messages will be queued until their total size exceeds this
 #         threshold value (or a timeout occurs, see below). Once the total size reaches this point,
 #         all queued messages will be bundled together and sent out in one packet.
@@ -213,7 +245,7 @@ portico.loglevel = INFO
 #
 # portico.jgroups.bundling.maxSize = 63000
 
-# (3.12) JGroups Bundling Max Timeout
+# (4.12) JGroups Bundling Max Timeout
 #         If bundling is enabled, messages will be queue either until their total size exceeds a
 #         threshold (see above) or the time that a message has been queued exceeds this value
 #         (provided in milliseconds). When this time is passed, a message is sent out, regardless
@@ -221,7 +253,7 @@ portico.loglevel = INFO
 #
 # portico.jgroups.bundling.maxTime = 25
 
-# (3.13) JGroups Flow Control
+# (4.13) JGroups Flow Control
 #         Flow control is used to limit the rate at which messages are sent so that slow receivers
 #         don't get overwhelmed, causing them to drop messages and requiring potentially expensive
 #         retransmission. This value sets the maximum number of bytes that can be sent by a federate
@@ -239,56 +271,4 @@ portico.loglevel = INFO
 #
 # portico.jgroups.flow.credits = 1000000
 
-# ================================
-# 4. Advanced Options
-# ================================
-# These really shouldn't be changed unless you really know what you want
 
-# (4.1) Portico Communications Binding
-#        This defines the communications binding Portico uses to talk to the federation. Two
-#        implementations are provided with Portico: "jgroups" (default) and "jvm". If you have
-#        a different binding, you can specify the fully-qualified name of the class that implements
-#        IConnection (e.g. an alternate way to specify the default JGroups communications binding
-#        would be "org.portico.bindings.jgroups.LrcConnection")
-#        DEFAULT = jgroups
-#
-# portico.connection = jgroups
-
-# (4.2) Commons Logging Level
-#        The commons library provides much of the underyling Portico infrastructure. If you want to
-#        see what it is logging, turn the level up (valid values the same as for 2.1). This is
-#        useful if you want to see what handlers are being loaded and associated with which messages
-#        or whether a certain plugin is being loaded successfully.
-#        DEFAULT = OFF
-#
-# portico.commons.loglevel = OFF
-
-# (4.3) LRC Tick Timeout
-#        When a federate calls tick() and there is no work to do, the LRC will wait for a period of
-#        time to allow work to arrive before it returns. This is designed to avoid a busy-looping
-#        situation where people are calling tick in a loop while waiting for some event.
-#
-#        The period of time the LRC will wait is specified by this value (in *MILLISECONDS*).
-#        DEFAULT = 5
-#
-#        (NOTE) This does not apply to the tick(min,max) call (in that case, the LRC will wait
-#               for at most "min" seconds for work to arrive).
-#
-# portico.lrc.tt = 5
-
-# ================================
-# 5. TCP Bridge Options
-# ================================
-# The option listed below is used to start a TCP server using the port specified.
-
-# (5.1) Portico Bridge TCP Server
-#        This enables the TCP Bridge Server to be started.
-#        DEFAULT = FALSE
-# portico.bridge.tcp_server = TRUE
-
-# (5.2) Portico Bridge Port
-#        This option is used to set the port required for the TCP Bridge Server to send and receive 
-#        messages on from the TCP Bridge Clients and for the TCP Bridge Client to send and receive
-#        messages from the TCP Bridge Server.
-#        DEFAULT = 0
-portico.bridge.tcp_port = 30001


### PR DESCRIPTION
Rearranged the RTI.rid file to structure things a bit more from the user perspective. Re-categorized some options so that they fit better in their groups and changed the order of the sections to put common RTI-operation parameters up the top and Portico structural things down the bottom.
