### PR TITLE
Temporary fix for PORT-82, just disabled the warning. To solve this

### DIFF
--- a/codebase/profiles/macosx/cpp.xml
+++ b/codebase/profiles/macosx/cpp.xml
@@ -130,11 +130,11 @@
 	<!-- ==================================== -->
 	<!--          HLA 1.3 Test Suite          -->
 	<!-- ==================================== -->
-	<target name="compile.test13">
+	<target name="compile.test13" depends="compile.ng6">
 		<cpp-unix outfile="test13"
 		          outdir="${test13.build.dir}"
 		          type="executable"
-		          compilerArgs="-g -arch i386"
+		          compilerArgs="-g -arch i386 -Wno-write-strings"
 		          linkerArgs="-arch i386">
 			<fileset dir="${test13.src.dir}" includes="**/*.cpp"/>
 			<includepath path="${hla13.include.dir}/ng6"/>


### PR DESCRIPTION
Temporary fix for PORT-82, just disabled the warning. To solve this what
really needs to happen is to go through and get rid of all the places I
use char\* and make sure they all use std::string. I started down that
path, but given the extensive use it's a bigger task than is possible
right now. Updated the build file for the stop-gap measure.
