### PR TITLE
The onejar ant task was only including .class files

### DIFF
--- a/codebase/profiles/java.xml
+++ b/codebase/profiles/java.xml
@@ -292,7 +292,6 @@
 			<!-- extract the deps for the one-jar style distribution -->
 			<unjar dest="${onejar.dir}">
 				<fileset dir="${lib.dir}" includes="**/*.jar" excludes="testng/**/*"/>
-				<patternset includes="**/*.class"/>
 			</unjar>
 		</else>
 		</if>


### PR DESCRIPTION
The onejar ant task was only including .class files extracted everything from the target jars. JGroups depends on a bunch of different XML files being present in the jar and as such, the onejar task now just extracts everything in the jar files into the main portico jar, rather than trying to be selective.
