### PR TITLE
PORT-121: Unsupported calls no longer throw an exception by default.

### DIFF
--- a/codebase/resources/dist/common/RTI.rid
+++ b/codebase/resources/dist/common/RTI.rid
@@ -88,12 +88,13 @@
 # portico.saveDirectory = ./savedata
 
 # (2.3) Unsupported Methods Throw Exceptions
-#        By default, if a user attempts to call a method on the RTI that is currently not supported
-#        by Portico, an RTIinternalError is thrown outlining that situation. This can cause some
-#        federates to crash if they are not expecting it or checking for it. If you set this value
-#        to false, no exception will be thrown and only a message will be logged.
+#        Portico does not support all the RTIambassador methods in all interface versions. To alert
+#        users to situations where a method is called that isn't support, Portico will log a warning
+#        and take no action. This is often a non-fatal action, but in some situations it may cause
+#        federates to stall or misbehave. As such, if this value is set to true, an RTIinternalError
+#        will be thrown when an unsupported method is called. By default, this is false.
 #
-# portico.unsupportedExceptions = true
+# portico.unsupportedExceptions = false
 
 # (2.4) Object Names Negotiated With Federation
 #        When registering an object with a specific name, to ensure that name is unique, the

--- a/codebase/src/java/portico/org/portico/impl/hla13/Rti13Ambassador.java
+++ b/codebase/src/java/portico/org/portico/impl/hla13/Rti13Ambassador.java
@@ -5869,7 +5869,7 @@ public class Rti13Ambassador implements RTIambassadorEx
 	 */
 	private void featureNotSupported( String methodName ) throws RTIinternalError
 	{
-		logger.error( "Rti13Ambassador doesn't yet support " + methodName );
+		logger.warn( "Rti13Ambassador doesn't yet support " + methodName );
 		if( PorticoConstants.shouldThrowExceptionForUnsupportedCall() )
 			throw new RTIinternalError( "Rti13Ambassador doesn't yet support " + methodName );
 	}

--- a/codebase/src/java/portico/org/portico/impl/hla1516/Rti1516Ambassador.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516/Rti1516Ambassador.java
@@ -4255,7 +4255,7 @@ public class Rti1516Ambassador implements RTIambassador
 	 */
 	private void featureNotSupported( String methodName ) throws RTIinternalError
 	{
-		logger.error( "Rti1516Ambassador doesn't yet support " + methodName );
+		logger.warn( "Rti1516Ambassador doesn't yet support " + methodName );
 		if( PorticoConstants.shouldThrowExceptionForUnsupportedCall() )
 			throw new RTIinternalError( "Rti1516Ambassador doesn't yet support " + methodName );
 	}

--- a/codebase/src/java/portico/org/portico/impl/hla1516e/Rti1516eAmbassador.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516e/Rti1516eAmbassador.java
@@ -5504,7 +5504,7 @@ public class Rti1516eAmbassador implements RTIambassador
 	 */
 	private void featureNotSupported( String methodName ) throws RTIinternalError
 	{
-		logger.error( "The IEEE 1516e interface doesn't yet support " + methodName );
+		logger.warn( "The IEEE 1516e interface doesn't yet support " + methodName );
 		if( PorticoConstants.shouldThrowExceptionForUnsupportedCall() )
 			throw new RTIinternalError( "The IEEE 1516e interface doesn't yet support "+methodName );
 	}

--- a/codebase/src/java/portico/org/portico/lrc/PorticoConstants.java
+++ b/codebase/src/java/portico/org/portico/lrc/PorticoConstants.java
@@ -158,7 +158,7 @@ public class PorticoConstants
 	public static final String PROPERTY_LOG_DIR = "portico.logdir";
 	
 	/** System property for defining whether or not calls to unsupported RTIambassador methods
-	    should result in an exception or not: default is to throw an RTIinternalError */
+	    should result in an exception or not: default is to NOT throw an exception */
 	public static final String PROPERTY_UNSUPPORTED_EXCEPTIONS = "portico.unsupportedExceptions";
 
 	/** System propery for defining whether or not to consult the other federates to check if an
@@ -566,10 +566,14 @@ public class PorticoConstants
 		updateLogValues();
 		return logFederateHandles;
 	}
-	
+
+	/**
+	 * @return True if the RTI ambassador should throw an exception if a federate attempts to
+	 *         call a method that is not yet support by Portico. False otherwise.
+	 */
 	public static boolean shouldThrowExceptionForUnsupportedCall()
 	{
-		return getBooleanProperty( PROPERTY_UNSUPPORTED_EXCEPTIONS, "true" );
+		return getBooleanProperty( PROPERTY_UNSUPPORTED_EXCEPTIONS, "false" );
 	}
 	
 	public static boolean isObjectNamingNegotiated()


### PR DESCRIPTION
They now just log a warning and move on with life.
