### PR TITLE
Patch to allow key variables to be passed to an existing running JVM - p...

### DIFF
--- a/codebase/src/cpp/ieee1516e/src/jni/Runtime.h
+++ b/codebase/src/cpp/ieee1516e/src/jni/Runtime.h
@@ -82,7 +82,8 @@ class Runtime
 		JavaRTI* getRtiAmbassador( int id );
 		void     removeRtiAmbassador( int id );
 		void     removeRtiAmbassador( JavaRTI* javarti );
-
+		void 	 setEnvSetting(const char* iKey, const char* iVal);
+		void 	 setEnvSetting(const char *iCompleteKey);
 
 	private:
 		void initializeJVM() throw( RTIinternalError );


### PR DESCRIPTION
Patch to allow key variables to be passed to an existing running JVM - probably just occurs within Matlab.

The same patch should probably be done for HLA 1.3 as well
