### PR TITLE
Fix PORT-162: Added service locator configuration file for time factory

### DIFF
--- a/codebase/resources/jars/portico.jar/META-INF/services/hla.rti1516e.LogicalTimeFactory
+++ b/codebase/resources/jars/portico.jar/META-INF/services/hla.rti1516e.LogicalTimeFactory
@@ -1,0 +1,2 @@
+org.portico.impl.hla1516e.types.time.DoubleTimeFactory
+org.portico.impl.hla1516e.types.time.IntegerTimeFactory


### PR DESCRIPTION
Fixes the issue with Pitch DS federates that use time management.
