### PR TITLE
PORT-184 Message Size Logging

### DIFF
--- a/codebase/resources/dist/common/RTI.rid
+++ b/codebase/resources/dist/common/RTI.rid
@@ -256,4 +256,14 @@
 #
 # portico.jgroups.flow.credits = 1000000
 
+# (4.12) JGroups Traffic Auditing
+#         If this option is enabled a special log file will be produced for each federate listing
+#         the messages it has sent and received. This information can be used to make judgements
+#         about network configuration (such as bundling) or to just see what is happening in the
+#         federation at a coarse level.
+#
+#         The audit files are placed in the logs directory (see sec 1.1) with the name:
+#         "audit-FEDERATENAME.log"
+#
+# portico.jgroups.auditor.enabled = false
 

--- a/codebase/src/java/portico/org/portico/bindings/jgroups/Auditor.java
+++ b/codebase/src/java/portico/org/portico/bindings/jgroups/Auditor.java
@@ -1,0 +1,182 @@
+/*
+ *   Copyright 2015 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico.bindings.jgroups;
+
+import java.io.IOException;
+import java.util.Date;
+
+import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
+import org.apache.log4j.RollingFileAppender;
+import org.portico.lrc.LRC;
+import org.portico.lrc.PorticoConstants;
+import org.portico.lrc.compat.JConfigurationException;
+import org.portico.lrc.management.Federate;
+import org.portico.utils.messaging.PorticoMessage;
+
+/**
+ * This class is used to log metadata about incoming/outgoing messages so that
+ * they can be audited later. This information is typically used to support decisions
+ * about configuration tweaks for performance tuning and to get an insight into
+ * how information is flowing through a federation.
+ * 
+ * The class wraps a simple Log4j logger that writes its information to a separate
+ * file from the main log so that is can be audited and followed without the additional
+ * noise of all the other goings on inside the LRC.
+ * 
+ * By default the Auditor is turned off, requiring enabling in the RID file.
+ */
+public class Auditor
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private boolean enabled;
+	private Logger logger;
+	private String receivedFormat;
+	private String sentFormat;
+	
+	private String federationName;
+	private String federateName;
+	private LRC lrc;
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public Auditor()
+	{
+		this.enabled = false;
+		this.logger = null;
+		this.federationName = "";
+		this.federateName = "";
+		
+		String timeFormat = "%1tH:%<tM:%<tS.%<tL";
+		this.receivedFormat = "received "+timeFormat+" %30s  %5d   from %s";
+		this.sentFormat     = "    sent "+timeFormat+" %30s  %5d   %s";
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	public final boolean isEnabled()
+	{
+		return this.enabled;
+	}
+
+	public void sent( PorticoMessage message, int size )
+	{
+		if( !enabled )
+			return;
+
+		// who are we sending this to?
+		int targetHandle = message.getTargetFederate();
+		String targetName = "";
+		if( targetHandle != -1 )
+		{
+			targetName = "  to "+lrc.getState().getKnownFederate(targetHandle).getFederateName()+
+			             "("+targetHandle+")";
+		}
+		
+		String type = message.getClass().getSimpleName();
+		String entry = String.format( sentFormat,
+		                              new Date(System.currentTimeMillis()),
+		                              type,
+		                              size,
+		                              targetName );
+		logger.info( entry );
+	}
+
+	public void received( PorticoMessage message, int size )
+	{
+		if( !enabled )
+			return;
+
+		// who sent this?
+		int sourceHandle = message.getSourceFederate();
+		Federate source = this.lrc.getState().getKnownFederate( sourceHandle );
+		String sourceName = "unknown("+sourceHandle+")";
+		if( source != null )
+			sourceName = source.getFederateName()+"("+sourceHandle+")";
+		
+		String type = message.getClass().getSimpleName();
+		String entry = String.format( receivedFormat,
+		                              new Date(System.currentTimeMillis()),
+		                              type,
+		                              size,
+		                              sourceName );
+		logger.info( entry );
+	}
+
+	///////////////////////////////////////////////////////////////////////////////
+	///////////////////////////////  Setup Methods  ///////////////////////////////
+	///////////////////////////////////////////////////////////////////////////////
+	/**
+	 * Enable the auditor and start collecting metadata. At this point in time the log file
+	 * will be created under "logs/audit-[federateName].log". 
+	 *  
+	 * @param federationName Used in an initial log message
+	 * @param federateName Used in the audit file name
+	 * @param lrc Used to convert federate names to handles for incoming/outgoing messages
+	 */
+	public void startAuditing( String federationName, String federateName, LRC lrc )
+		throws JConfigurationException
+	{
+		if( this.enabled )
+			return;
+		
+		this.federationName = federationName;
+		this.federateName = federateName;
+		this.lrc = lrc;
+		turnLoggerOn();
+		this.enabled = true;
+	}
+
+	/**
+	 * Create and configure out logger and file appender so that we can start recording.
+	 */
+	private void turnLoggerOn() throws JConfigurationException
+	{
+		try
+		{
+			// log file is in logs/audit-federateName.log
+			String logdir = System.getProperty( PorticoConstants.PROPERTY_LOG_DIR, "logs" );
+			String logfile = logdir +"/audit-"+this.federateName+".log";
+
+    		// create the appender for the logger
+			String pattern = new String( "%m%n" );
+    		PatternLayout layout = new PatternLayout( pattern );
+    		RollingFileAppender appender = new RollingFileAppender( layout, logfile, true );
+    		appender.setMaxBackupIndex( 2 );
+    		appender.setMaxFileSize( "10MB" );
+    		
+    		// attach the appender
+    		this.logger = Logger.getLogger( "auditor" );
+    		this.logger.addAppender( appender );
+		}
+		catch( IOException ioex )
+		{
+			throw new JConfigurationException( "error configuring auditor log: "+ioex.getMessage(), ioex );
+		}
+	}
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/portico/org/portico/bindings/jgroups/Auditor.java
+++ b/codebase/src/java/portico/org/portico/bindings/jgroups/Auditor.java
@@ -15,11 +15,17 @@
 package org.portico.bindings.jgroups;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.apache.log4j.Logger;
 import org.apache.log4j.PatternLayout;
 import org.apache.log4j.RollingFileAppender;
+import org.jgroups.Version;
 import org.portico.lrc.LRC;
 import org.portico.lrc.PorticoConstants;
 import org.portico.lrc.compat.JConfigurationException;
@@ -47,21 +53,25 @@ public class Auditor
 	//----------------------------------------------------------
 	//                   INSTANCE VARIABLES
 	//----------------------------------------------------------
-	private boolean enabled;
+	private boolean recording;
 	private Logger logger;
+	private RollingFileAppender appender; // keep a ref so we can close out safely
 	private String receivedFormat;
 	private String sentFormat;
 	
 	private String federationName;
 	private String federateName;
 	private LRC lrc;
+	
+	// counters and metrics
+	private Map<String,MessageMetrics> metrics;
 
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
 	//----------------------------------------------------------
 	public Auditor()
 	{
-		this.enabled = false;
+		this.recording = false;
 		this.logger = null;
 		this.federationName = "";
 		this.federateName = "";
@@ -69,22 +79,35 @@ public class Auditor
 		String timeFormat = "%1tH:%<tM:%<tS.%<tL";
 		this.receivedFormat = "received "+timeFormat+" %30s  %5d   from %s";
 		this.sentFormat     = "    sent "+timeFormat+" %30s  %5d   %s";
+		
+		// counters and metrics
+		this.metrics = new HashMap<String,MessageMetrics>();
 	}
 
 	//----------------------------------------------------------
 	//                    INSTANCE METHODS
 	//----------------------------------------------------------
 
-	public final boolean isEnabled()
+	/**
+	 * @return True if the auditor is currently recording content. False if it is not.
+	 */
+	public final boolean isRecording()
 	{
-		return this.enabled;
+		return this.recording;
 	}
 
+	/**
+	 * The local federate just sent the given message. When serialized, the message was the
+	 * given size in bytes.
+	 * 
+	 * @param message The message that was sent
+	 * @param size The serialized size of the message
+	 */
 	public void sent( PorticoMessage message, int size )
 	{
-		if( !enabled )
+		if( !recording )
 			return;
-
+		
 		// who are we sending this to?
 		int targetHandle = message.getTargetFederate();
 		String targetName = "";
@@ -101,11 +124,33 @@ public class Auditor
 		                              size,
 		                              targetName );
 		logger.info( entry );
+
+		// log some metrics
+		MessageMetrics counter = metrics.get( type );
+		if( counter == null )
+		{
+			counter = new MessageMetrics( type );
+			metrics.put( type, counter );
+		}
+		
+		counter.totalSent += 1;
+		counter.totalSentSize += size;
 	}
 
+	/**
+	 * The local federate just received the given message. When received on the wire, the
+	 * message was the given size in bytes.
+	 * 
+	 * @param message The message that was received
+	 * @param size The serialized size of the message
+	 */
 	public void received( PorticoMessage message, int size )
 	{
-		if( !enabled )
+		if( !recording )
+			return;
+
+		// discard our own messages as they're not coming from the network
+		if( message.getSourceFederate() == lrc.getState().getFederateHandle() )
 			return;
 
 		// who sent this?
@@ -122,6 +167,17 @@ public class Auditor
 		                              size,
 		                              sourceName );
 		logger.info( entry );
+		
+		// log some metrics
+		MessageMetrics counter = metrics.get( type );
+		if( counter == null )
+		{
+			counter = new MessageMetrics( type );
+			metrics.put( type, counter );
+		}
+		
+		counter.totalReceived += 1;
+		counter.totalReceivedSize += size;
 	}
 
 	///////////////////////////////////////////////////////////////////////////////
@@ -138,14 +194,20 @@ public class Auditor
 	public void startAuditing( String federationName, String federateName, LRC lrc )
 		throws JConfigurationException
 	{
-		if( this.enabled )
+		if( this.recording )
 			return;
 		
 		this.federationName = federationName;
 		this.federateName = federateName;
 		this.lrc = lrc;
 		turnLoggerOn();
-		this.enabled = true;
+		this.recording = true;
+		
+		// log a startup message with some useful information
+		logger.info( "Starting Audit log for federate ["+federateName+"] in federation ["+
+		             federationName );
+		logger.info( "Portico "+PorticoConstants.RTI_VERSION + " - JGroups "+Version.description );
+		logger.info( "" );
 	}
 
 	/**
@@ -162,9 +224,9 @@ public class Auditor
     		// create the appender for the logger
 			String pattern = new String( "%m%n" );
     		PatternLayout layout = new PatternLayout( pattern );
-    		RollingFileAppender appender = new RollingFileAppender( layout, logfile, true );
+    		this.appender = new RollingFileAppender( layout, logfile, true );
     		appender.setMaxBackupIndex( 2 );
-    		appender.setMaxFileSize( "10MB" );
+    		appender.setMaxFileSize( "100MB" );
     		
     		// attach the appender
     		this.logger = Logger.getLogger( "auditor" );
@@ -176,7 +238,169 @@ public class Auditor
 		}
 	}
 
+	/**
+	 * The federation execution is now over - wrap up the auditing by printing a final summary
+	 * and closing out the file.
+	 */
+	public void stopAuditing()
+	{
+		if( this.recording == false )
+			return;
+		
+		this.federationName = "";
+		this.federateName = "";
+		this.lrc = null;
+		this.recording = false;
+		
+		// print the execution summary before we leave
+		logSummary();
+		
+		// turn the logger off
+		this.logger.removeAppender( appender );
+		this.appender.close();
+	}
+	
+	private void logSummary()
+	{
+		// get some totals
+		long sentCount = 0;
+		long sentSize = 0;
+		long receivedCount = 0;
+		long receivedSize = 0;
+		int longestName = 0;
+		for( String message : metrics.keySet() )
+		{
+			MessageMetrics temp = metrics.get( message );
+			sentCount     += temp.totalSent;
+			sentSize      += temp.totalSentSize;
+			receivedCount += temp.totalReceived;
+			receivedSize  += temp.totalReceivedSize;
+			
+			if( message.length() > longestName )
+				longestName = message.length();
+		}
+		
+		// print a report
+		String finishTime = String.format( "%1tH:%<tM:%<tS.%<tL", new Date(System.currentTimeMillis()) );
+		String sentString = String.format( "%6d (%s)", sentCount, getSizeString(sentSize) );
+		String receivedString = String.format( "%6d (%s)", receivedCount, getSizeString(receivedSize) );
+		
+		logger.info( "" );
+		logger.info( "==============================================" );
+		logger.info( "  Execution Summary" );
+		logger.info( "==============================================" );
+		logger.info( "     Finish Time: "+finishTime );
+		logger.info( "      Total Sent: "+sentString );
+		logger.info( "  Total Received: "+receivedString );
+		logger.info( "" );
+		
+		// events table
+		logger.info("  |-----------------------------|-------------------------------|-------------------------------|" );
+		logger.info("  |                             |  Sent                         |  Received                     |" );
+		logger.info("  |                             |---------------------------------------------------------------|" );
+		logger.info("  | Message Name                |  Count  |   Size    |   Avg   |  Count  |   Size    |   Avg   |" );
+		logger.info("  |-----------------------------|-------------------------------|-------------------------------|" );
+
+		List<MessageMetrics> ordered = new ArrayList<MessageMetrics>( metrics.values() );
+		Collections.sort( ordered );
+		for( MessageMetrics temp : ordered )
+		{
+			// figure out the averages - may have received by not sent (or vv) meaning
+			// we are exposed to divide-by-zero problems if we don't check first
+			String sentAvg = "";
+			String sentTotal = "";
+			if( temp.totalSent > 0 )
+			{
+				sentAvg = getSizeString(temp.totalSentSize/temp.totalSent);
+				sentTotal = ""+temp.totalSent;
+			}
+
+			String receivedAvg = "";
+			String receivedTotal = "";
+			if( temp.totalReceived > 0 )
+			{
+				receivedAvg = getSizeString(temp.totalReceivedSize/temp.totalReceived);
+				receivedTotal = ""+temp.totalReceived;
+			}
+
+			String line = String.format( "  | %27s | %7s | %9s |%8s | %7s | %9s |%8s |",
+			                             temp.className,
+			                             sentTotal,
+			                             getSizeString(temp.totalSentSize),
+			                             sentAvg,
+			                             receivedTotal,
+			                             getSizeString(temp.totalReceivedSize),
+			                             receivedAvg );
+			logger.info( line );
+		}
+
+		logger.info("  |-----------------------------|-------------------------------|-------------------------------|" );
+		logger.info( String.format("  |                       Total | %7d | %9s |%8s | %7d | %9s |%8s |",
+		                           sentCount,
+		                           getSizeString(sentSize),
+		                           getSizeString(sentSize/sentCount),
+		                           receivedCount,
+		                           getSizeString(receivedSize),
+		                           getSizeString(receivedSize/receivedCount)) );
+		logger.info("  |-----------------------------|-------------------------------|-------------------------------|" );
+		logger.info( "" );
+	}
+
+	/**
+	 * Convert the given size (in bytes) to a more human readable string. Returned values
+	 * will be in the form: "16B", "16KB", "16MB", "16GB".
+	 */
+	private String getSizeString( long size )
+	{
+		if( size == 0 )
+			return "";
+		
+		double totalkb = size / 1024;
+		double totalmb = totalkb / 1024;
+		double totalgb = totalmb / 1024;
+		if( totalgb > 1.0 )
+			return String.format("%5.1f GB", totalgb );
+		else if( totalmb > 1.0 )
+			return String.format("%5.1f MB", totalmb );
+		else if( totalkb > 1.0 )
+			return String.format("%5.1f KB", totalkb );
+		else
+			return String.format("%5d B ", size );
+	}
 	//----------------------------------------------------------
 	//                     STATIC METHODS
 	//----------------------------------------------------------
+	
+	////////////////////////////////////////////////////////////////////////////////
+	////////////////////  Private Inner Class: Message Metrics  ////////////////////
+	////////////////////////////////////////////////////////////////////////////////
+	/**
+	 * Used to store information about the messages sent and received by the federate.
+	 * This information is stored per message class.
+	 */
+	private class MessageMetrics implements Comparable<MessageMetrics>
+	{
+		public String className;
+		public long totalSent;
+		public long totalSentSize; // fine up to 8 exabytes
+		public long totalReceived;
+		public long totalReceivedSize;
+		
+		public MessageMetrics( String className )
+		{
+			this.className = className;
+		}
+		
+		public int compareTo( MessageMetrics other )
+		{
+			// this comparision is reverse - as we want the large values at the front of the list
+			long ours = totalSentSize + totalReceivedSize;
+			long theirs = other.totalSentSize + totalReceivedSize;
+			if( ours > theirs )
+				return -1;
+			else if( ours < theirs )
+				return 1;
+			else return 0;
+		}
+	}
 }

--- a/codebase/src/java/portico/org/portico/bindings/jgroups/JGroupsProperties.java
+++ b/codebase/src/java/portico/org/portico/bindings/jgroups/JGroupsProperties.java
@@ -42,6 +42,9 @@ public class JGroupsProperties
 	    that there is no existing co-ordinator and appointing ourselves to that lofty title */
 	public static String PROP_JGROUPS_GMS_TIMEOUT = "portico.jgroups.gms.jointimeout";
 
+	/** Whether or not the auditor is enabled */
+	public static String PROP_JGROUPS_AUDITOR_ENABLED = "portico.jgroups.auditor.enabled";
+
 	///// jgroups properties /////////////////////////////////////////////////////////////////
 	/** The amount of time (in milliseconds) to wait for a response to a request, defaults to 1000,
 	    controllable through system property {@link #PROP_JGROUPS_TIMEOUT}  */
@@ -80,4 +83,14 @@ public class JGroupsProperties
 	{
 		return Boolean.valueOf( System.getProperty(PROP_JGROUPS_DAEMON,"true") );
 	}
+
+	/**
+	 * @return True if the Auditor has been turned on in configuration, false otherwise.
+	 *         Default is false.
+	 */
+	public static final boolean isAuditorEnabled()
+	{
+		return Boolean.valueOf( System.getProperty(PROP_JGROUPS_AUDITOR_ENABLED,"false") );
+	}
+	
 }

--- a/codebase/src/java/portico/org/portico/bindings/jgroups/MessageReceiver.java
+++ b/codebase/src/java/portico/org/portico/bindings/jgroups/MessageReceiver.java
@@ -39,14 +39,16 @@ public class MessageReceiver
 	//----------------------------------------------------------
 	private LRC lrc;
 	private Logger logger;
+	private Auditor auditor;
 
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
 	//----------------------------------------------------------
-	public MessageReceiver()
+	public MessageReceiver( Auditor auditor )
 	{
 		this.lrc = null;
 		this.logger = Logger.getLogger( "portico.lrc.jgroups" );
+		this.auditor = auditor;
 	}
 
 	//----------------------------------------------------------
@@ -78,6 +80,11 @@ public class MessageReceiver
     		if( payload == null )
    				return;
     		
+    		// log an audit entry for the reception
+    		if( auditor.isEnabled() )
+    			auditor.received( payload, message.getLength() );
+    		
+    		// shove into our queue for later processing
     		lrc.getState().getQueue().offer( payload );
 		}
 		catch( Exception e )
@@ -102,6 +109,10 @@ public class MessageReceiver
 			PorticoMessage payload = MessageHelpers.inflate( message.getBuffer(),
 			                                                 PorticoMessage.class );
 			
+    		// log an audit entry for the reception
+    		if( auditor.isEnabled() )
+    			auditor.received( payload, message.getLength() );
+
 			MessageContext context = new org.portico.utils.messaging.MessageContext( payload );
 			lrc.getIncomingSink().process( context );
 			return context.getResponse();

--- a/codebase/src/java/portico/org/portico/bindings/jgroups/MessageReceiver.java
+++ b/codebase/src/java/portico/org/portico/bindings/jgroups/MessageReceiver.java
@@ -81,7 +81,7 @@ public class MessageReceiver
    				return;
     		
     		// log an audit entry for the reception
-    		if( auditor.isEnabled() )
+    		if( auditor.isRecording() )
     			auditor.received( payload, message.getLength() );
     		
     		// shove into our queue for later processing
@@ -110,7 +110,7 @@ public class MessageReceiver
 			                                                 PorticoMessage.class );
 			
     		// log an audit entry for the reception
-    		if( auditor.isEnabled() )
+    		if( auditor.isRecording() )
     			auditor.received( payload, message.getLength() );
 
 			MessageContext context = new org.portico.utils.messaging.MessageContext( payload );

--- a/codebase/src/java/portico/org/portico/bindings/jgroups/channel/FederationChannel.java
+++ b/codebase/src/java/portico/org/portico/bindings/jgroups/channel/FederationChannel.java
@@ -232,7 +232,7 @@ public class FederationChannel
 		message.setBuffer( data );
 
 		// Log an audit message for the send
-		if( auditor.isEnabled() )
+		if( auditor.isRecording() )
 			auditor.sent( payload, data.length );
 		
 		// write the message
@@ -386,6 +386,7 @@ public class FederationChannel
 		// manifest as it updates it for any federate resignation
 		logger.info( "SUCCESS Federate ["+federateName+"] resigned from ["+federationName+"]" );
 		this.receiver.unlink();
+		this.auditor.stopAuditing();
 	}
 
 	/**


### PR DESCRIPTION
Added a message audit log feature that when enabled in the RID will print information about each message sent and received by a federate. Information includes the direction, type of message, size, etc... Some summary information is also included at the conclusion. Sample output looks like below (taken from the end of an audit file put together on a test run:

```
received 15:13:28.434                   DeleteObject    213   from unknown(2)
received 15:13:28.434                   DeleteObject    213   from unknown(2)
received 15:13:28.434                   DeleteObject    213   from unknown(2)
received 15:13:28.435                   DeleteObject    213   from unknown(2)
received 15:13:28.435                   DeleteObject    213   from unknown(2)
received 15:13:28.435                   DeleteObject    213   from unknown(2)
received 15:13:28.435                   DeleteObject    213   from unknown(2)
received 15:13:28.436                   DeleteObject    213   from unknown(2)
received 15:13:28.436                   DeleteObject    213   from unknown(2)
received 15:13:28.436                   DeleteObject    213   from unknown(2)
received 15:13:28.436                   DeleteObject    213   from unknown(2)
received 15:13:28.436                   DeleteObject    213   from unknown(2)
received 15:13:28.453               ResignFederation    456   from unknown(2)
    sent 15:13:28.517               ResignFederation    456   

==============================================
  Execution Summary
==============================================
     Finish Time: 15:13:28.520
      Total Sent:  40081 (159.2 MB)
  Total Received:  40082 (159.2 MB)

  |-----------------------------|-------------------------------|-------------------------------|
  |                             |  Sent                         |  Received                     |
  |                             |---------------------------------------------------------------|
  | Message Name                |  Count  |   Size    |   Avg   |  Count  |   Size    |   Avg   |
  |-----------------------------|-------------------------------|-------------------------------|
  |            UpdateAttributes |   20020 |   79.6 MB |  4.0 KB |   20020 |   79.6 MB |  4.0 KB |
  |             SendInteraction |   20000 |   79.6 MB |  4.0 KB |   20000 |   79.6 MB |  4.0 KB |
  |                    RoleCall |       2 |    6.0 KB |  3.0 KB |       2 |   1096 B  |  548 B  |
  |              DiscoverObject |      21 |    5.0 KB |  287 B  |      21 |    5.0 KB |  287 B  |
  |                DeleteObject |      21 |    4.0 KB |  213 B  |      21 |    4.0 KB |  213 B  |
  |        SubscribeObjectClass |       2 |    866 B  |  433 B  |       2 |    866 B  |  433 B  |
  |          PublishObjectClass |       2 |    824 B  |  412 B  |       2 |    824 B  |  412 B  |
  |   SubscribeInteractionClass |       3 |    801 B  |  267 B  |       3 |    801 B  |  267 B  |
  |     PublishInteractionClass |       3 |    708 B  |  236 B  |       3 |    708 B  |  236 B  |
  |       SyncPointAnnouncement |       2 |    669 B  |  334 B  |       2 |    671 B  |  335 B  |
  |     SyncRegistrationRequest |       2 |    605 B  |  302 B  |       2 |    607 B  |  303 B  |
  |           SyncPointAchieved |       2 |    527 B  |  263 B  |       2 |    527 B  |  263 B  |
  |            ResignFederation |       1 |    456 B  |  456 B  |       2 |    912 B  |  456 B  |
  |-----------------------------|-------------------------------|-------------------------------|
  |                       Total |   40081 |  159.2 MB |  4.0 KB |   40082 |  159.2 MB |  4.0 KB |
  |-----------------------------|-------------------------------|-------------------------------|
```

