### PR TITLE
Audit Logging Extensions (FOM-Specific Info and Filtering)

### DIFF
--- a/codebase/resources/dist/common/RTI.rid
+++ b/codebase/resources/dist/common/RTI.rid
@@ -267,3 +267,19 @@
 #
 # portico.jgroups.auditor.enabled = false
 
+# (4.13) JGroups Traffic Audit Filtering
+#         Federates can generate a lot of messages. Sometimes you really just want to zero in
+#         on a particular type of message, or messages for a particular FOM type. These filters
+#         let you do that. These filters work in combination. For example, consider the following:
+#             - action  = sent
+#             - type    = UpdateAttributes
+#             - fomtype = Lifeform, GroundVehicle
+#
+#         Given this, only attribute updates for the FOM classes "Lifeform" and "GroundVehicle"
+#         that the local federate sends will be logged. Leaving a value empty, or using the
+#         keyword "all" will cause no filtering for that type to be applied.
+#         
+# portico.jgroups.auditor.filter.direction = 
+# portico.jgroups.auditor.filter.message   = 
+# portico.jgroups.auditor.filter.fomtype   = 
+

--- a/codebase/src/java/portico/org/portico/bindings/jgroups/JGroupsProperties.java
+++ b/codebase/src/java/portico/org/portico/bindings/jgroups/JGroupsProperties.java
@@ -14,6 +14,10 @@
  */
 package org.portico.bindings.jgroups;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
 /**
  * All configuration information is stored in system properties as keys. This class
  * provides statics that can be used to identify the specific keys.
@@ -42,8 +46,14 @@ public class JGroupsProperties
 	    that there is no existing co-ordinator and appointing ourselves to that lofty title */
 	public static String PROP_JGROUPS_GMS_TIMEOUT = "portico.jgroups.gms.jointimeout";
 
+	///// auditor settings
 	/** Whether or not the auditor is enabled */
 	public static String PROP_JGROUPS_AUDITOR_ENABLED = "portico.jgroups.auditor.enabled";
+
+	/** Auditor filtering settings */
+	public static String PROP_JGROUPS_AUDITOR_FILTER_DIR = "portico.jgroups.auditor.filter.direction";
+	public static String PROP_JGROUPS_AUDITOR_FILTER_MSG = "portico.jgroups.auditor.filter.message";
+	public static String PROP_JGROUPS_AUDITOR_FILTER_FOM = "portico.jgroups.auditor.filter.fomtype";
 
 	///// jgroups properties /////////////////////////////////////////////////////////////////
 	/** The amount of time (in milliseconds) to wait for a response to a request, defaults to 1000,
@@ -91,6 +101,55 @@ public class JGroupsProperties
 	public static final boolean isAuditorEnabled()
 	{
 		return Boolean.valueOf( System.getProperty(PROP_JGROUPS_AUDITOR_ENABLED,"false") );
+	}
+
+	/**
+	 * @return A list of all the configured direction filters. If no configuration is provided,
+	 *         list will contain one entry - "all". These will be converted to lower case before
+	 *         being returned.
+	 */
+	public static List<String> getAuditorDirectionFilters()
+	{
+		String value = System.getProperty( PROP_JGROUPS_AUDITOR_FILTER_DIR,"all");
+		return explode( value, "," );
+	}
+	
+	/**
+	 * @return A list of all the configured message filters. If no configuration is provided,
+	 *         list will contain one entry - "all". These will be converted to lower case before
+	 *         being returned.
+	 */
+	public static List<String> getAuditorMessageFilters()
+	{
+		String value = System.getProperty( PROP_JGROUPS_AUDITOR_FILTER_MSG,"all");
+		return explode( value, "," );
+	}
+	
+	/**
+	 * @return A list of all the configured fomtype filters. If no configuration is provided,
+	 *         list will contain one entry - "all". These will be converted to lower case before
+	 *         being returned.
+	 */
+	public static List<String> getAuditorFomtypeFilters()
+	{
+		String value = System.getProperty( PROP_JGROUPS_AUDITOR_FILTER_FOM,"all");
+		return explode( value, "," );
+	}
+	
+	private static List<String> explode( String string, String delimiter )
+	{
+		List<String> list = new ArrayList<String>();
+		StringTokenizer tokenizer = new StringTokenizer( string, delimiter );
+		while( tokenizer.hasMoreTokens() )
+		{
+			String temp = tokenizer.nextToken().trim();
+			if( temp.equals("") )
+				continue;
+			else
+				list.add( temp );
+		}
+		
+		return list;
 	}
 	
 }


### PR DESCRIPTION
PORT-187, #58
This PR adds support to the JGroups auditor to include:

  * FOM-specific information in log messages (object/interaction class, object name/id, attribute/param counts)
  * FOM-specific summary (breaks down messages by both type, and object/interaction class)
  * Filtering (can restrict the messages the auditor will log)