### PR TITLE
HLA 1.3 64-bit DLLs named with suffix _64

### DIFF
--- a/codebase/profiles/linux/hla13.xml
+++ b/codebase/profiles/linux/hla13.xml
@@ -86,7 +86,7 @@
 			<includepath path="${cppunit.include}"/>
 			<define name="RTI_USES_STD_FSTREAM"/>
 			<define name="DEBUG"/>
-			<library path="${hla13.complete.dir}/gcc4" libs="RTI-NG64d,FedTime64d"/>
+			<library path="${hla13.complete.dir}/gcc4" libs="RTI-NG_64d,FedTime_64d"/>
 			<library path="${cppunit.lib}" libs="cppunit"/>
 		</cpptask>
 	</target>
@@ -267,7 +267,7 @@
 
 			<!-- Are we building for 32-bit or 64-bit? -->
 			<if><equals arg1="@{arch}" arg2="amd64"/><then>
-				<property name="_bitness" value="64"/>
+				<property name="_bitness" value="_64"/>
 				<property name="_jdklib" value="${jdk.home.linux64}/jre/lib/amd64/server"/>
 			</then><else>
 				<property name="_bitness" value=""/>

--- a/codebase/profiles/macosx/dlc13.xml
+++ b/codebase/profiles/macosx/dlc13.xml
@@ -67,7 +67,7 @@
 	<!--            HLA 1.3 Interface            -->
 	<!-- ======================================= -->
 	<target name="compile.amd64.debug">
-		<cpp-unix outfile="rti1364d"
+		<cpp-unix outfile="rti13_64d"
 		          workdir="${dlc13.build.dir}"
 		          arch="amd64"
 		          compilerArgs="-g -O1 -fPIC -Wall -Wno-non-virtual-dtor -stdlib=libstdc++"
@@ -94,7 +94,7 @@
 	</target>
 
 	<target name="compile.amd64.release" if="build.release">
-		<cpp-unix outfile="rti1364"
+		<cpp-unix outfile="rti13_64"
 		          workdir="${dlc13.build.dir}"
 		          arch="amd64"
 		          compilerArgs="-O1 -fPIC -Wall -Wno-non-virtual-dtor"

--- a/codebase/profiles/macosx/hla13.xml
+++ b/codebase/profiles/macosx/hla13.xml
@@ -321,7 +321,7 @@
 
 			<!-- Are we building for 32-bit or 64-bit? -->
 			<if><equals arg1="@{arch}" arg2="amd64"/><then>
-				<property name="_bitness" value="64"/>
+				<property name="_bitness" value="_64"/>
 				<property name="_jdklib" value="${jdk.home.macosx}/jre/lib/server"/>
 			</then><else>
 				<property name="_bitness" value=""/>

--- a/codebase/profiles/macosx/test13.xml
+++ b/codebase/profiles/macosx/test13.xml
@@ -43,7 +43,7 @@
 	<!--                                  Compile Targets                                  -->
 	<!-- ================================================================================= -->
 	<target name="compile" depends="cpp.hla13.compile">
-		<gcc-test13 compiler="gcc4" arch="amd64" build="debug"/>
+		<test-hla13 compiler="gcc4" arch="amd64" build="debug"/>
 	</target>
 
 	<!-- ================================================ -->
@@ -64,22 +64,14 @@
 			</then>
 			<else>
 				<echo message="[Compile] (HLA v1.3 Test Suite) @{compiler}.@{arch}.@{build}"/>
-
-				<!--                                                  -->
-				<!-- Generate the build-specific local ant properties -->
-				<!--                                                  -->
-				<cpplocals compiler="@{compiler}" arch="@{arch}" build="@{build}">
-					<debug cargs="-g -O0 -fPIC -Wall -stdlib=libstdc++ -Wno-c++11-compat-deprecated-writable-strings"/>
-					<release cargs="-O0 -fPIC -Wall -stdlib=libstdc++ -Wno-c++11-compat-deprecated-writable-strings"/>
-				</cpplocals>
-
 				<cpptask compiler="g++"
-				         outfile="test13-@{arch}"
+				         outfile="test13"
 				         workdir="${test13.build.dir}/@{arch}"
-				         outdir="${test13.complete.dir}/@{arch}"
+				         outdir="${test13.complete.dir}"
 				         type="executable"
-				         arch="@{arch}"
-				         compilerArgs="${_cargs}">
+				         arch="amd64"
+				         compilerArgs="-g -O0 -fPIC -Wall -stdlib=libstdc++ -Wno-c++11-compat-deprecated-writable-strings"
+				         linkerArgs=" -stdlib=libstdc++">
 					<fileset dir="${hla13.test.src.dir}" includes="**/*.cpp"/>
 					<includepath path="${hla13.include.dir}"/>
 					<includepath path="${hla13.src.dir}/hla/time"/>
@@ -87,7 +79,7 @@
 					<define name="RTI_USES_STD_FSTREAM"/>
 					<define name="DEBUG"/>
 					<library path="${hla13.complete.dir}/gcc4"
-					         libs="RTI-NG${_bitness}${_d},FedTime${_bitness}${_d}"/>
+					         libs="RTI-NG_64d,FedTime_64d"/>
 					<library path="${cppunit.lib}" libs="cppunit"/>
 				</cpptask>
 			</else></if>

--- a/codebase/profiles/windows/hla13.xml
+++ b/codebase/profiles/windows/hla13.xml
@@ -335,7 +335,7 @@
 
 			<!-- Are we building for 32-bit or 64-bit? -->
 			<if><equals arg1="@{arch}" arg2="amd64"/><then>
-				<property name="_bitness" value="64"/>
+				<property name="_bitness" value="_64"/>
 				<property name="_jdkhome" value="${jdk.home.win64}"/>
 			</then><else>
 				<property name="_bitness" value=""/>

--- a/codebase/src/java/portico/org/portico/impl/cpp13/NativeLibraryLoader.java
+++ b/codebase/src/java/portico/org/portico/impl/cpp13/NativeLibraryLoader.java
@@ -99,7 +99,7 @@ public class NativeLibraryLoader
 		
 		// append for 64-bit
 		if( PorticoConstants.isCpp64bit() )
-			libraryName += "64";
+			libraryName += "_64";
 		
 		// append for a debug library
 		if( PorticoConstants.isCppDebugSession() )
@@ -153,7 +153,7 @@ public class NativeLibraryLoader
 		
 		// append for 64-bit
 		if( PorticoConstants.isCpp64bit() )
-			libraryName += "64";
+			libraryName += "_64";
 		
 		// append for a debug library
 		if( PorticoConstants.isCppDebugSession() )


### PR DESCRIPTION
PORT-186 #59 Updated the build system to produce HLA 1.3 binaries with the suffix "_64" rather than just "64". Also updated the native library loader (which loads the native libraries into the java space to support calling back across the boundary for C++ federates). Tested and working on the Mac. Travis will test Linux and I'll manually test Windows.