### PR TITLE
PORT-99 HLA13 cpp tests no longer cause deprecated string transform warnings

### DIFF
--- a/codebase/profiles/macosx/hla13.xml
+++ b/codebase/profiles/macosx/hla13.xml
@@ -58,7 +58,7 @@
 		         outdir="${test13.complete.dir}"
 		         type="executable"
 		         arch="amd64"
-		         compilerArgs="-g -O0 -fPIC -Wall -stdlib=libstdc++ -Wno-c++11-compat-deprecated-writable-strings"
+		         compilerArgs="-g -O0 -fPIC -Wall -stdlib=libstdc++"
 		         linkerArgs="-stdlib=libstdc++">
 			<fileset dir="${hla13.test.src.dir}" includes="**/*.cpp"/>
 			<includepath path="${hla13.include.dir}"/>

--- a/codebase/profiles/macosx/test13.xml
+++ b/codebase/profiles/macosx/test13.xml
@@ -70,7 +70,7 @@
 				         outdir="${test13.complete.dir}"
 				         type="executable"
 				         arch="amd64"
-				         compilerArgs="-g -O0 -fPIC -Wall -stdlib=libstdc++ -Wno-c++11-compat-deprecated-writable-strings"
+				         compilerArgs="-g -O0 -fPIC -Wall -stdlib=libstdc++"
 				         linkerArgs=" -stdlib=libstdc++">
 					<fileset dir="${hla13.test.src.dir}" includes="**/*.cpp"/>
 					<includepath path="${hla13.include.dir}"/>

--- a/codebase/src/cpp/hla13/test/common/Common.cpp
+++ b/codebase/src/cpp/hla13/test/common/Common.cpp
@@ -39,7 +39,7 @@ void failTest( const char *format, ... )
  * Test should fail because an exception was expected, but none occurred. The failure message
  * will also include the action that was underway (and should have caused an exception).
  */
-void failTestMissingException( char *expectedException, char* action )
+void failTestMissingException( const char *expectedException, const char* action )
 {
 	char buffer[4096];
 	sprintf( buffer,
@@ -54,7 +54,7 @@ void failTestMissingException( char *expectedException, char* action )
  * include the expected and actual exception types and a message regarding the action that
  * was in progress.
  */
-void failTestWrongException( char *expected, RTI::Exception &actual, char *action )
+void failTestWrongException( const char *expected, RTI::Exception &actual, const char *action )
 {
 	char buffer[4096];
 	sprintf( buffer,

--- a/codebase/src/cpp/hla13/test/common/Common.h
+++ b/codebase/src/cpp/hla13/test/common/Common.h
@@ -67,16 +67,16 @@
  * maps we define using ltstr comparision. Stupid MSVC doesn't
  * like using the other version. Humbug.
  */
-#define MAP_LTSTR_CLEANUP(mapname)                      \
-{                                                       \
-	map<char*,char*,ltstr>::iterator iterator;          \
-	for( iterator = mapname->begin();                   \
-	     iterator != mapname->end();                    \
-	     iterator++ )                                   \
-	{                                                   \
-		char *current = (*iterator).second;             \
-		delete current;                                 \
-	}                                                   \
+#define MAP_LTSTR_CLEANUP(mapname)                          \
+{                                                           \
+	map<const char*,const char*,ltstr>::iterator iterator;  \
+	for( iterator = mapname->begin();                       \
+	     iterator != mapname->end();                        \
+	     iterator++ )                                       \
+	{                                                       \
+		const char *current = (*iterator).second;           \
+		delete current;                                     \
+	}                                                       \
 }
 
 /*
@@ -116,12 +116,12 @@
  */
 #define SET_LTSTR_CLEANUP(setname)                      \
 {                                                       \
-	set<char*,ltstr>::iterator iterator;                \
+	set<const char*,ltstr>::iterator iterator;          \
 	for( iterator = setname->begin();                   \
 	     iterator != setname->end();                    \
 	     iterator++ )                                   \
 	{                                                   \
-		char *current = *iterator;                      \
+		const char *current = *iterator;                \
 		delete current;                                 \
 	}                                                   \
 }
@@ -139,13 +139,13 @@ void failTest( const char *format, ... );
  * Test should fail because an exception was expected, but none occurred. The failure message
  * will also include the action that was underway (and should have caused an exception).
  */
-void failTestMissingException( char *expectedException, char* action );
+void failTestMissingException( const char *expectedException, const char* action );
 
 /*
  * An exception was received, but it wasn't the one we expected. The failure message will
  * include the expected and actual exception types and a message regarding the action that
  * was in progress.
  */
-void failTestWrongException( char *expected, RTI::Exception &actual, char *action );
+void failTestWrongException( const char *expected, RTI::Exception &actual, const char *action );
 
 #endif /*COMMON_H_*/

--- a/codebase/src/cpp/hla13/test/common/Test13Federate.cpp
+++ b/codebase/src/cpp/hla13/test/common/Test13Federate.cpp
@@ -15,14 +15,14 @@
 #include "Test13Federate.h"
 
 // set up the static vars
-char *Test13Federate::SIMPLE_NAME = "TestNG6Federation";
+const char *Test13Federate::SIMPLE_NAME = "TestNG6Federation";
 int Test13Federate::OWNER_UNOWNED = -1;
 int Test13Federate::OWNER_RTI = 0;
 
 //////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////// Constructors ////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////
-Test13Federate::Test13Federate( char *name )
+Test13Federate::Test13Federate( const char* name )
 {
 	// store the federate name (make sure it is a copy so that we can delete it when we want)
 	//this->federateName = name;
@@ -71,7 +71,7 @@ void Test13Federate::quickCreate()
  * This method will create a new federation using the given federation name and the default
  * testing FOM.
  */
-void Test13Federate::quickCreate( char *federationName )
+void Test13Federate::quickCreate( const char* federationName )
 {
 	try
 	{
@@ -89,14 +89,14 @@ void Test13Federate::quickCreate( char *federationName )
  */
 RTI::FederateHandle Test13Federate::quickJoin()
 {
-	// just call into quickJoin( char* )
+	// just call into quickJoin( const char* )
 	return this->quickJoin( Test13Federate::SIMPLE_NAME );
 }
 
 /*
  * The same as quickJoin() except that you can specify the federation name. 
  */
-RTI::FederateHandle Test13Federate::quickJoin( char *federationName )
+RTI::FederateHandle Test13Federate::quickJoin( const char* federationName )
 {
 	// create the FederateAmbassador implementation, removing the current one if it exists
 	if( this->fedamb != NULL )
@@ -161,7 +161,7 @@ void Test13Federate::quickDestroy()
 /*
  * This method will attempt to destroy the federation of the given name.
  */
-void Test13Federate::quickDestroy( char *federationName )
+void Test13Federate::quickDestroy( const char* federationName )
 {
 	try
 	{
@@ -197,7 +197,7 @@ void Test13Federate::quickDestroyNoFail()
  * Attempt to register a federation wide synchronization point with the given label and tag. If
  * the tag is NULL, "NA" will be passed
  */
-void Test13Federate::quickAnnounce( char *label, char *tag )
+void Test13Federate::quickAnnounce( const char* label, const char* tag )
 {
 	// check the tag
 	if( tag == NULL )
@@ -218,7 +218,9 @@ void Test13Federate::quickAnnounce( char *label, char *tag )
  * handles will be used to identify which federates should be privy to the point. If the given
  * tag is NULL, "NA" will be passed.
  */
-void Test13Federate::quickAnnounce( char *label, int federateCount, ... /* federate handles */ )
+void Test13Federate::quickAnnounce( const char* label, 
+                                    int federateCount, 
+                                    ... /* federate handles */ )
 {
 	// convert the handle set
 	RTI::FederateHandleSet *handleSet = this->createFHS( federateCount );
@@ -246,7 +248,7 @@ void Test13Federate::quickAnnounce( char *label, int federateCount, ... /* feder
  * Attempt to sign to the RTI that this federate has achieved the synchronization point with
  * the given label
  */
-void Test13Federate::quickAchieved( char *label )
+void Test13Federate::quickAchieved( const char* label )
 {
 	try
 	{
@@ -297,7 +299,7 @@ void Test13Federate::quickPublish( int objectClass, int attributeCount, ... )
  * parameter is the number of attributes that should be published. This method will resolve the
  * handles on behalf of the user from the given names.
  */
-void Test13Federate::quickPublish( char *objectClass, int attributeCount, ... )
+void Test13Federate::quickPublish( const char* objectClass, int attributeCount, ... )
 {
 	// resolve the handle for the class
 	RTI::ObjectClassHandle classHandle = quickOCHandle( objectClass );
@@ -328,7 +330,7 @@ void Test13Federate::quickPublish( char *objectClass, int attributeCount, ... )
  * Attempts to unpublish all attributes of the class with the given name. If there is an error,
  * the current test is failed.
  */
-void Test13Federate::quickUnpublishOC( char *objectClass )
+void Test13Federate::quickUnpublishOC( const char* objectClass )
 {
 	// resolve the handle for the class
 	RTI::ObjectClassHandle classHandle = quickOCHandle( objectClass );
@@ -378,7 +380,7 @@ void Test13Federate::quickSubscribe( int objectClass, int attributeCount, ... )
  * parameter is the number of attributes that should be published. This method will resolve the
  * handles on behalf of the user from the given names.
  */
-void Test13Federate::quickSubscribe( char *objectClass, int attributeCount, ... )
+void Test13Federate::quickSubscribe( const char* objectClass, int attributeCount, ... )
 {
 	// resolve the handle for the class
 	RTI::ObjectClassHandle classHandle = quickOCHandle( objectClass );
@@ -426,7 +428,7 @@ void Test13Federate::quickPublish( int interactionClass )
  * Attempts to publish the interaction class identified by the given class name. This method
  * will resolve the handle on behalf of the caller.
  */
-void Test13Federate::quickPublish( char *interactionClass )
+void Test13Federate::quickPublish( const char* interactionClass )
 {
 	// resolve the handle for the class
 	RTI::InteractionClassHandle classHandle = this->quickICHandle( interactionClass );
@@ -462,7 +464,7 @@ void Test13Federate::quickSubscribe( int interactionClass )
  * Attempts to subscribe to the interaction class identified by the given class name. This method
  * will resolve the handle on behalf of the caller.
  */
-void Test13Federate::quickSubscribe( char *interactionClass )
+void Test13Federate::quickSubscribe( const char* interactionClass )
 {
 	// resolve the handle
 	RTI::InteractionClassHandle classHandle = this->quickICHandle( interactionClass );
@@ -501,7 +503,7 @@ RTI::ObjectHandle Test13Federate::quickRegister( int classHandle )
 /*
  * The same as quickRegister(int), except that you can provide the name to use for the object
  */
-RTI::ObjectHandle Test13Federate::quickRegister( int classHandle, char *objectName )
+RTI::ObjectHandle Test13Federate::quickRegister( int classHandle, const char* objectName )
 {
 	try
 	{
@@ -519,7 +521,7 @@ RTI::ObjectHandle Test13Federate::quickRegister( int classHandle, char *objectNa
  * it will return the handle of the object that has been registered. The method will resolve
  * the handle for the object class on behalf of the user.
  */
-RTI::ObjectHandle Test13Federate::quickRegister( char* className )
+RTI::ObjectHandle Test13Federate::quickRegister( const char* className )
 {
 	// resolve the handle before the request
 	RTI::ObjectClassHandle classHandle = this->quickOCHandle( className );
@@ -538,7 +540,7 @@ RTI::ObjectHandle Test13Federate::quickRegister( char* className )
 /*
  * The same as quickRegister(char*) except that you can provide the object name
  */
-RTI::ObjectHandle Test13Federate::quickRegister( char* className, char *objectName )
+RTI::ObjectHandle Test13Federate::quickRegister( const char* className, const char* objectName )
 {
 	// resolve the handle before the request
 	RTI::ObjectClassHandle classHandle = this->quickOCHandle( className );
@@ -576,7 +578,7 @@ void Test13Federate::quickRegisterFail( int classHandle )
  * This method will attempt to delete the object instance identified by the given handle and
  * will pass the given tag. If the tag is NULL, it will be replaced with "NA".
  */
-void Test13Federate::quickDelete( int objectHandle, char *tag )
+void Test13Federate::quickDelete( int objectHandle, const char* tag )
 {
 	// check the tag
 	if( tag == NULL )
@@ -602,7 +604,7 @@ void Test13Federate::quickDelete( int objectHandle, char *tag )
  */
 void Test13Federate::quickReflect( int objectHandle,
                                     RTI::AttributeHandleValuePairSet *ahvps,
-                                    char *tag )
+                                    const char* tag )
 {
 	// check the tag
 	if( tag == NULL )
@@ -670,16 +672,15 @@ void Test13Federate::quickReflect( int objectHandle, int attributeCount, ... )
  */
 void Test13Federate::quickReflectFail( int objectHandle,
                                        RTI::AttributeHandleValuePairSet *ahvps,
-                                       char *tag )
+                                       const char *tag )
 {
 	// check the tag
-	if( tag == NULL )
-		tag = "NA";
+	const char* safeTag = tag == NULL ? "NA" : tag;
 	
 	// attempt the update
 	try
 	{
-		rtiamb->updateAttributeValues( objectHandle, *ahvps, tag );
+		rtiamb->updateAttributeValues( objectHandle, *ahvps, safeTag );
 		killTest( "Was expecting an exception during the updateAttributeValues call" );
 	}
 	catch( RTI::Exception &e )
@@ -692,7 +693,9 @@ void Test13Federate::quickReflectFail( int objectHandle,
  * Attempt to send an interaction of the class that has its handle provided with the given
  * set of parameter values. If the tag is NULL, it will be replaced with "NA".
  */
-void Test13Federate::quickSend( int clazz, RTI::ParameterHandleValuePairSet *phvps, char *tag )
+void Test13Federate::quickSend( int clazz, 
+                                RTI::ParameterHandleValuePairSet *phvps, 
+                                const char* tag )
 {
 	// check the tag
 	if( tag == NULL )
@@ -805,17 +808,16 @@ void Test13Federate::quickSend( int classHandle, double time, int parameterCount
  * and if it doesn't, the current test will be killed.
  */
 void Test13Federate::quickSendFail( int classHandle,
-                                     RTI::ParameterHandleValuePairSet *phvps,
-                                     char *tag )
+                                    RTI::ParameterHandleValuePairSet *phvps,
+                                    const char *tag )
 {
 	// check the tag
-	if( tag == NULL )
-		tag = "NA";
+	const char* safeTag = tag == NULL ? "NA" : tag;
 	
 	// attempt the interaction
 	try
 	{
-		rtiamb->sendInteraction( classHandle, *phvps, tag );
+		rtiamb->sendInteraction( classHandle, *phvps, safeTag );
 		killTest( "Was expecting an exception during the sendInteraction call" );
 	}
 	catch( RTI::Exception &e )
@@ -831,7 +833,7 @@ void Test13Federate::quickSendFail( int classHandle,
  * Find and return the space handle for the space of the given name. Kill the test if there is
  * an exception.
  */
-RTI::SpaceHandle Test13Federate::quickSpaceHandle( char* spaceName )
+RTI::SpaceHandle Test13Federate::quickSpaceHandle( const char* spaceName )
 {
 	try
 	{
@@ -848,7 +850,8 @@ RTI::SpaceHandle Test13Federate::quickSpaceHandle( char* spaceName )
  * Find and return the dimension handle for the dimension of the given name in the space of the
  * given name. Kill the test if there is an exception.
  */
-RTI::DimensionHandle Test13Federate::quickDimensionHandle( char* spaceName, char* dimensionName )
+RTI::DimensionHandle Test13Federate::quickDimensionHandle( const char* spaceName, 
+                                                           const char* dimensionName )
 {
 	RTI::SpaceHandle spaceHandle = quickSpaceHandle( spaceName );
 	try
@@ -988,7 +991,7 @@ RTI::Region* Test13Federate::quickGetRegion( RTI::RegionToken regionToken )
  * region. If there is an exception during this process, kill the test, otherwise, return the
  * handle of the newly created instance.
  */
-RTI::ObjectHandle Test13Federate::quickRegisterWithRegion( char* objectClass,
+RTI::ObjectHandle Test13Federate::quickRegisterWithRegion( const char* objectClass,
                                                             RTI::Region* theRegion,
                                                             int attributeCount,
                                                             ... /* attribute names */ )
@@ -1071,7 +1074,8 @@ void Test13Federate::quickAssociateWithRegion( RTI::ObjectHandle theObject,
  * Unassociate any attributes of the identified object instance that are associated with the
  * given region. If there is an exception trying to do this, the current test will be killed.
  */
-void Test13Federate::quickUnassociateWithRegion( RTI::ObjectHandle theObject, RTI::Region* theRegion )
+void Test13Federate::quickUnassociateWithRegion( RTI::ObjectHandle theObject, 
+                                                 RTI::Region* theRegion )
 
 {
 	try
@@ -1120,7 +1124,7 @@ void Test13Federate::quickSubscribeWithRegion( RTI::ObjectClassHandle classHandl
  * Subscribe to the identified object class for each of the given attribute (names) using the
  * given region. If there is an exception while trying to do this, the current test will be killed.
  */
-void Test13Federate::quickSubscribeWithRegion( char* className,
+void Test13Federate::quickSubscribeWithRegion( const char* className,
                                                 RTI::Region* region,
                                                 int attributeCount, 
                                                 ... /* attribute names */ )
@@ -1169,7 +1173,7 @@ void Test13Federate::quickUnsubscribeOCWithRegion( RTI::ObjectClassHandle classH
  * Unsubscribe from the given object class with the given region. If there is an exception during
  * this process, kill the current test.
  */
-void Test13Federate::quickUnsubscribeOCWithRegion( char* className, RTI::Region* region )
+void Test13Federate::quickUnsubscribeOCWithRegion( const char* className, RTI::Region* region )
 {
 	try
 	{
@@ -1197,7 +1201,7 @@ void Test13Federate::quickSubscribeWithRegion( RTI::InteractionClassHandle class
 	}
 }
 
-void Test13Federate::quickSubscribeWithRegion( char* className, RTI::Region* region )
+void Test13Federate::quickSubscribeWithRegion( const char* className, RTI::Region* region )
 {
 	try
 	{
@@ -1230,7 +1234,7 @@ void Test13Federate::quickUnsubscribeICWithRegion( RTI::InteractionClassHandle c
  * Unsubscribe from the given interaction class with the given region. If there is an exception
  * during this process, kill the current test.
  */
-void Test13Federate::quickUnsubscribeICWithRegion( char* className, RTI::Region *region )
+void Test13Federate::quickUnsubscribeICWithRegion( const char* className, RTI::Region *region )
 {
 	try
 	{
@@ -1246,7 +1250,7 @@ void Test13Federate::quickUnsubscribeICWithRegion( char* className, RTI::Region 
  * Much the same as quickSend(int,int,...) except that you can include region data. As usual,
  * if there are any problems, the current test will be killed.
  */
-void Test13Federate::quickSendWithRegion( char *interactionClass,
+void Test13Federate::quickSendWithRegion( const char* interactionClass,
                                            RTI::Region *region,
                                            int parameterCount,
                                            ... /* parameter names */ )
@@ -1789,7 +1793,7 @@ void Test13Federate::quickAssertOwnedBy( int federateHandle,
  * the request or the initiation isn't received in a timely fashion, the current test
  * will be failed.
  */
-void Test13Federate::quickSaveInProgress( char *saveLabel )
+void Test13Federate::quickSaveInProgress( const char* saveLabel )
 {
 	// initiate a save from this federate using the given label
 	this->quickSaveRequest( saveLabel );
@@ -1801,7 +1805,7 @@ void Test13Federate::quickSaveInProgress( char *saveLabel )
 /*
  * Request a federation save with the given label, fail the test if there is an exception
  */
-void Test13Federate::quickSaveRequest( char *saveLabel )
+void Test13Federate::quickSaveRequest( const char* saveLabel )
 {
 	try
 	{
@@ -1871,7 +1875,7 @@ void Test13Federate::quickSaveNotComplete()
  * given label. If there is a problem in any of the steps (initiating the save, starting it
  * or successfully completing in any of the federates), the current test will be failed.
  */
-void Test13Federate::quickSaveToCompletion( char *saveLabel, int federateCount, ... )
+void Test13Federate::quickSaveToCompletion( const char* saveLabel, int federateCount, ... )
 {
 	// initiate a save from this federate using the given label
 	quickSaveRequest( saveLabel );
@@ -1910,7 +1914,7 @@ void Test13Federate::quickSaveToCompletion( char *saveLabel, int federateCount, 
  * Requests a federation restore from the RTIambassador and then returns. If there is an
  * exception performing this call, the current test is failed.
  */
-void Test13Federate::quickRestoreRequest( char *label )
+void Test13Federate::quickRestoreRequest( const char* label )
 {
 	try
 	{
@@ -1927,7 +1931,7 @@ void Test13Federate::quickRestoreRequest( char *label )
  * then ticks until either a success of failure notification from the RTI is received. If the
  * initiation is not a success, or there is an exception initiating it, the current test is failed.
  */
-void Test13Federate::quickRestoreRequestSuccess( char *label )
+void Test13Federate::quickRestoreRequestSuccess( const char* label )
 {
 	quickRestoreRequest( label );
 	fedamb->waitForRestoreRequestSuccess( label );
@@ -1971,7 +1975,7 @@ void Test13Federate::quickRestoreNotComplete()
  * for the save and the restore. The set of all the federates is received from the test
  * class that this federate is associated with. 
  */
-void Test13Federate::quickRestoreInProgress( char *saveLabel, int federateCount, ... )
+void Test13Federate::quickRestoreInProgress( const char* saveLabel, int federateCount, ... )
 {
 	///////////////////////////////////////////////////
 	////////////////// complete save //////////////////
@@ -2031,7 +2035,7 @@ void Test13Federate::quickRestoreInProgress( char *saveLabel, int federateCount,
 /*
  * Fetch the handle for the given object class
  */
-RTI::ObjectClassHandle Test13Federate::quickOCHandle( char *objectClass )
+RTI::ObjectClassHandle Test13Federate::quickOCHandle( const char* objectClass )
 {
 	try
 	{
@@ -2047,7 +2051,8 @@ RTI::ObjectClassHandle Test13Federate::quickOCHandle( char *objectClass )
 /*
  * Fetch the handle for the given attribute contained in the given object class
  */
-RTI::AttributeHandle Test13Federate::quickACHandle( char *objectClass, char *attributeName )
+RTI::AttributeHandle Test13Federate::quickACHandle( const char* objectClass, 
+                                                    const char* attributeName )
 {
 	try
 	{
@@ -2063,7 +2068,7 @@ RTI::AttributeHandle Test13Federate::quickACHandle( char *objectClass, char *att
 /*
  * Fetch the handle for the identified interaction class
  */
-RTI::InteractionClassHandle Test13Federate::quickICHandle( char *interactionClass )
+RTI::InteractionClassHandle Test13Federate::quickICHandle( const char* interactionClass )
 {
 	try
 	{
@@ -2079,7 +2084,8 @@ RTI::InteractionClassHandle Test13Federate::quickICHandle( char *interactionClas
 /*
  * Fetch the handle for the identified parameter in the given interaction class
  */
-RTI::ParameterHandle Test13Federate::quickPCHandle( char *interactionClass, char *parameterName )
+RTI::ParameterHandle Test13Federate::quickPCHandle( const char* interactionClass, 
+                                                    const char* parameterName )
 {
 	try
 	{
@@ -2306,7 +2312,7 @@ void Test13Federate::quickTick( double min, double max )
  * CPPUNIT_FAIL to kill the active test. The activeMethod parameter should be the name of the
  * method that was active at the time of the exception.
  */
-void Test13Federate::killTest( RTI::Exception &e, char *activeMethod )
+void Test13Federate::killTest( RTI::Exception &e, const char* activeMethod )
 {
 	// create a message notifying of the death
 	char message[4096];

--- a/codebase/src/cpp/hla13/test/common/Test13Federate.h
+++ b/codebase/src/cpp/hla13/test/common/Test13Federate.h
@@ -26,7 +26,7 @@ class Test13Federate
 	//                    STATIC VARIABLES
 	//----------------------------------------------------------
 	public:
-		static char *SIMPLE_NAME;
+		static const char *SIMPLE_NAME;
 		static int OWNER_UNOWNED;
 		static int OWNER_RTI;
 
@@ -44,7 +44,7 @@ class Test13Federate
 	//                      CONSTRUCTORS
 	//----------------------------------------------------------
 	public:
-		Test13Federate( char *name );
+		Test13Federate( const char* name );
 		~Test13Federate();
 
 	//----------------------------------------------------------
@@ -58,64 +58,71 @@ class Test13Federate
 		///// federation management helpers /////
 		/////////////////////////////////////////
 		void quickCreate();
-		void quickCreate( char *federationName );
+		void quickCreate( const char* federationName );
 		RTI::FederateHandle quickJoin();
-		RTI::FederateHandle quickJoin( char *federationName );
+		RTI::FederateHandle quickJoin( const char* federationName );
 		void quickResign();
 		void quickResign( RTI::ResignAction action );
 		void quickDestroy();
-		void quickDestroy( char *federationName );
+		void quickDestroy( const char* federationName );
 		void quickDestroyNoFail();
 
 		/////////////////////////////////////////
 		///// synchronization point helpers /////
 		/////////////////////////////////////////
-		void quickAnnounce( char *label, char *tag );
-		void quickAnnounce( char *label, int federateCount, ... /* federate handles */ );
-		void quickAchieved( char *label );
+		void quickAnnounce( const char* label, const char* tag );
+		void quickAnnounce( const char* label, int federateCount, ... /* federate handles */ );
+		void quickAchieved( const char* label );
 
 		/////////////////////////////////////////
 		///// publish and subscribe helpers /////
 		/////////////////////////////////////////
 		void quickPublish( int objectClass, int attributeCount, ... /* attribute handles */ );
-		void quickPublish( char *objectClass, int attributeCount, ... /* attribute names */ );
+		void quickPublish( const char* objectClass, int attributeCount, ... /* attribute names */ );
 		void quickSubscribe( int objectClass, int attributeCount, ... /* attribute handles */ );
-		void quickSubscribe( char *objectClass, int attributeCount, ... /* attribute names */ );
+		void quickSubscribe( const char* objectClass, int attributeCount, ... /* attribute names */ );
 
 		void quickPublish( int interactionClass );
-		void quickPublish( char *interactionClass );
+		void quickPublish( const char* interactionClass );
 		void quickSubscribe( int interactionClass );
-		void quickSubscribe( char *interactionClass );
+		void quickSubscribe( const char* interactionClass );
 		
-		void quickUnpublishOC( char *objectClass );
+		void quickUnpublishOC( const char* objectClass );
 
 		///////////////////////////////////////////////
 		///// object registration/removal helpers /////
 		///////////////////////////////////////////////
 		RTI::ObjectHandle quickRegister( int classHandle );
-		RTI::ObjectHandle quickRegister( int classHandle, char *objectName );
-		RTI::ObjectHandle quickRegister( char* className );
-		RTI::ObjectHandle quickRegister( char* className, char *objectName );
+		RTI::ObjectHandle quickRegister( int classHandle, const char* objectName );
+		RTI::ObjectHandle quickRegister( const char* className );
+		RTI::ObjectHandle quickRegister( const char* className, const char* objectName );
 		void              quickRegisterFail( int classHandle );
-		void              quickDelete( int objectHandle, char *tag );
+		void              quickDelete( int objectHandle, const char* tag );
 
 		//////////////////////////////////////////////
 		///// reflection and interaction helpers /////
 		//////////////////////////////////////////////
-		void quickReflect( int objectHandle, RTI::AttributeHandleValuePairSet *ahvps, char *tag );
+		void quickReflect( int objectHandle, 
+		                   RTI::AttributeHandleValuePairSet *ahvps, 
+		                   const char* tag );
 		void quickReflect( int objectHandle, int attributeCount, ... /* attribute names */ );
-		void quickReflectFail( int handle, RTI::AttributeHandleValuePairSet *ahvps, char *tag );
+		void quickReflectFail( int handle, 
+		                       RTI::AttributeHandleValuePairSet *ahvps, 
+		                       const char* tag );
 		
-		void quickSend( int classHandle, RTI::ParameterHandleValuePairSet *phvps, char *tag );
+		void quickSend( int classHandle, RTI::ParameterHandleValuePairSet *phvps, const char* tag );
 		void quickSend( int classHandle, int parameterCount, ... /* parameter names */ );
 		void quickSend( int classHandle, double time, int parameterCount, ... /* parameter names */ );
-		void quickSendFail( int classHandle, RTI::ParameterHandleValuePairSet *phvps, char *tag );
+		void quickSendFail( int classHandle, 
+		                    RTI::ParameterHandleValuePairSet *phvps, 
+		                    const char* tag );
 
 		////////////////////////////////////////////////
 		///// data distribution management methods /////
 		////////////////////////////////////////////////
-		RTI::SpaceHandle     quickSpaceHandle( char* spaceName );
-		RTI::DimensionHandle quickDimensionHandle( char* spaceName, char* dimensionName );
+		RTI::SpaceHandle     quickSpaceHandle( const char* spaceName );
+		RTI::DimensionHandle quickDimensionHandle( const char* spaceName, 
+		                                           const char* dimensionName );
 		RTI::Region*         quickCreateRegion( RTI::SpaceHandle space, RTI::ULong extents );
 		RTI::Region*         quickCreateTestRegion( RTI::ULong lowerBound, RTI::ULong upperBound );
 		RTI::Region*         quickCreateOtherRegion( RTI::ULong lowerBound, RTI::ULong upperBound );
@@ -123,7 +130,7 @@ class Test13Federate
 		RTI::RegionToken     quickGetRegionToken( RTI::Region* theRegion );
 		RTI::Region*         quickGetRegion( RTI::RegionToken regionToken );
 		
-		RTI::ObjectHandle    quickRegisterWithRegion( char* objectClass,
+		RTI::ObjectHandle    quickRegisterWithRegion( const char* objectClass,
 		                                              RTI::Region* theRegion,
 		                                              int attributeCount,
 		                                              ... /* attribute names */ );
@@ -138,22 +145,24 @@ class Test13Federate
 		                                               RTI::Region* region,
 		                                               int attributeCount,
 		                                               ... /* attribute handles */ );
-		void                 quickSubscribeWithRegion( char* className,
+		void                 quickSubscribeWithRegion( const char* className,
 		                                               RTI::Region* region,
 		                                               int attributeCount, 
 		                                               ... /* attribute names */ );
 		void                 quickUnsubscribeOCWithRegion( RTI::ObjectClassHandle classHandle,
 		                                                   RTI::Region *region );
-		void                 quickUnsubscribeOCWithRegion( char* className, RTI::Region* region );
+		void                 quickUnsubscribeOCWithRegion( const char* className, 
+		                                                   RTI::Region* region );
 
 		void                 quickSubscribeWithRegion( RTI::InteractionClassHandle classhandle,
 		                                               RTI::Region* region );
-		void                 quickSubscribeWithRegion( char* className, RTI::Region* region );
+		void                 quickSubscribeWithRegion( const char* className, RTI::Region* region );
 		void                 quickUnsubscribeICWithRegion( RTI::InteractionClassHandle classHandle,
 		                                                   RTI::Region *region );
-		void                 quickUnsubscribeICWithRegion( char* className, RTI::Region *region );
+		void                 quickUnsubscribeICWithRegion( const char* className, 
+		                                                   RTI::Region *region );
 
-		void quickSendWithRegion( char *classHandle,
+		void quickSendWithRegion( const char* classHandle,
 		                          RTI::Region *region,
 		                          int parameterCount,
 		                          ... /* parameter names */ );
@@ -199,26 +208,28 @@ class Test13Federate
 		//////////////////////////////////////////////
 		////////// save and restore helpers //////////
 		//////////////////////////////////////////////
-		void quickSaveRequest( char *saveLabel );
+		void quickSaveRequest( const char* saveLabel );
 		void quickSaveBegun();
 		void quickSaveComplete();
 		void quickSaveNotComplete();
-		void quickSaveInProgress( char *saveLabel );
-		void quickSaveToCompletion( char *saveLabel, int federateCount, ... );
+		void quickSaveInProgress( const char* saveLabel );
+		void quickSaveToCompletion( const char* saveLabel, int federateCount, ... );
 		
-		void quickRestoreRequest( char *saveLabel );
-		void quickRestoreRequestSuccess( char *saveLabel );
+		void quickRestoreRequest( const char* saveLabel );
+		void quickRestoreRequestSuccess( const char* saveLabel );
 		void quickRestoreComplete();
 		void quickRestoreNotComplete();
-		void quickRestoreInProgress( char *saveLabel, int federateCount, ... );
+		void quickRestoreInProgress( const char* saveLabel, int federateCount, ... );
 		
 		////////////////////////////////////////////
 		///// handle resolution helper methods /////
 		////////////////////////////////////////////
-		RTI::ObjectClassHandle      quickOCHandle( char *objectClass );
-		RTI::AttributeHandle        quickACHandle( char *objectClass, char *attributeName );
-		RTI::InteractionClassHandle quickICHandle( char *interactionClass );
-		RTI::ParameterHandle        quickPCHandle( char *interactionClass, char *parameterName );
+		RTI::ObjectClassHandle      quickOCHandle( const char* objectClass );
+		RTI::AttributeHandle        quickACHandle( const char* objectClass, 
+		                                           const char* attributeName );
+		RTI::InteractionClassHandle quickICHandle( const char* interactionClass );
+		RTI::ParameterHandle        quickPCHandle( const char* interactionClass, 
+		                                           const char* parameterName );
 		RTI::ObjectClassHandle      quickOCHandle( int objectHandle );
 		char*                       quickOCName( RTI::ObjectClassHandle classHandle );
 		char*                       quickOCNameForInstance( int objectHandle );
@@ -240,7 +251,7 @@ class Test13Federate
 		RTI::RTIambassador* getRtiAmb();
 		void quickTick();
 		void quickTick( double min, double max );
-		void killTest( RTI::Exception &e, char *activeMethod );
+		void killTest( RTI::Exception &e, const char* activeMethod );
 		void killTest( const char *format, ... );
 
 	//----------------------------------------------------------

--- a/codebase/src/cpp/hla13/test/common/Test13FederateAmbassador.cpp
+++ b/codebase/src/cpp/hla13/test/common/Test13FederateAmbassador.cpp
@@ -30,8 +30,8 @@ Test13FederateAmbassador::Test13FederateAmbassador( Test13Federate *testFederate
 	// initialize the instance vars
 	this->constrained        = RTI::RTI_FALSE;
 	this->regulating         = RTI::RTI_FALSE;
-	this->announced          = new map<char*, char*, ltstr>();
-	this->synchronized       = new set<char*, ltstr>();
+	this->announced          = new map<const char*, const char*, ltstr>();
+	this->synchronized       = new set<const char*, ltstr>();
 	this->logicalTime        = 0.0;
 	this->syncRegResult      = WAITING;
 	
@@ -124,7 +124,7 @@ time_t Test13FederateAmbassador::getCurrentTime()
  * has, the CppUnit macros will be used to kill the current test, and the currentMethod will
  * be identified in the failure message.
  */
-void Test13FederateAmbassador::checkTimeout( time_t startTime, char *currentMethod )
+void Test13FederateAmbassador::checkTimeout( time_t startTime, const char* currentMethod )
 {
 	double difference = difftime( getCurrentTime(), startTime );
 	if( difference > TIMEOUT )
@@ -165,7 +165,7 @@ RTI::Boolean Test13FederateAmbassador::checkTimeoutNonFatal( time_t startTime )
 /*
  * Check to see if the sync point with the given label has been announced or not
  */
-RTI::Boolean Test13FederateAmbassador::isAnnounced( char* label )
+RTI::Boolean Test13FederateAmbassador::isAnnounced( const char* label )
 {
 	if( this->announced->count(label) == 0 )
 		return RTI::RTI_FALSE;
@@ -176,7 +176,7 @@ RTI::Boolean Test13FederateAmbassador::isAnnounced( char* label )
 /*
  * Check to see if the federation has synchronized on the given sync point or not
  */
-RTI::Boolean Test13FederateAmbassador::isSynchronized( char* label )
+RTI::Boolean Test13FederateAmbassador::isSynchronized( const char* label )
 {
 	if( this->synchronized->count(label) == 0 )
 		return RTI::RTI_FALSE;
@@ -188,7 +188,7 @@ RTI::Boolean Test13FederateAmbassador::isSynchronized( char* label )
  * Wait for the given sync point to be announced. If it doesn't happen before a timeout
  * occurs, CppUnit will be used to fail the current test.
  */
-char* Test13FederateAmbassador::waitForSyncAnnounce( char* label )
+const char* Test13FederateAmbassador::waitForSyncAnnounce( const char* label )
 {
 	// wait for the point to be announced
 	time_t startTime = this->getCurrentTime();
@@ -210,7 +210,7 @@ char* Test13FederateAmbassador::waitForSyncAnnounce( char* label )
  * in that it EXPECTS there to be a timeout. If the request doesn't timeout, it will fail the
  * current test.
  */
-void Test13FederateAmbassador::waitForSyncAnnounceTimeout( char* label )
+void Test13FederateAmbassador::waitForSyncAnnounceTimeout( const char* label )
 {
 	// wait for the point to be announced
 	time_t startTime = this->getCurrentTime();
@@ -236,7 +236,7 @@ void Test13FederateAmbassador::waitForSyncAnnounceTimeout( char* label )
  * If the registration request is a success, RTI_TRUE is returned, if not, RTI_FALSE. If there
  * is no response before a timeout occurs, the current test will be failed.
  */
-RTI::Boolean Test13FederateAmbassador::waitForSyncRegResult( char* label )
+RTI::Boolean Test13FederateAmbassador::waitForSyncRegResult( const char* label )
 {
 	// clear the current values
 	this->syncRegResult = WAITING;
@@ -266,7 +266,7 @@ RTI::Boolean Test13FederateAmbassador::waitForSyncRegResult( char* label )
  * the actual result, this method will return normally. If the result differs, the current
  * test will be failed.
  */
-void Test13FederateAmbassador::waitForSyncRegResult( char* label, RTI::Boolean expectedResult )
+void Test13FederateAmbassador::waitForSyncRegResult( const char* label, RTI::Boolean expectedResult )
 {
 	// wait for the result
 	RTI::Boolean result = waitForSyncRegResult( label );
@@ -282,7 +282,7 @@ void Test13FederateAmbassador::waitForSyncRegResult( char* label, RTI::Boolean e
  * This method will wait until the federation has synchronized on the given sync point. If the
  * notification doesn't come through before a timeout, the current unit test will be failed.
  */
-void Test13FederateAmbassador::waitForSynchronized( char* label )
+void Test13FederateAmbassador::waitForSynchronized( const char* label )
 {
 	// wait for us to feel that funky synchronized love
 	time_t startTime = this->getCurrentTime();
@@ -301,7 +301,7 @@ void Test13FederateAmbassador::waitForSynchronized( char* label )
  * synchronized on the point with the given label. If this happens BEFORE a timeout occurs,
  * the current test will be failed. If a timeout occurs, this method will return normally.
  */
-void Test13FederateAmbassador::waitForSynchornizedTimeout( char* label )
+void Test13FederateAmbassador::waitForSynchornizedTimeout( const char* label )
 {
 	// wait for the federation to synchronize
 	time_t startTime = this->getCurrentTime();
@@ -423,8 +423,8 @@ Test13Object* Test13FederateAmbassador::waitForDiscoveryAs( RTI::ObjectHandle ob
  * was expected.
  */
 Test13Object* Test13FederateAmbassador::waitForDiscoveryAsWithName( RTI::ObjectHandle objectHandle,
-                                                                      RTI::ObjectClassHandle asClass,
-                                                                      char *expectedName )
+                                                                    RTI::ObjectClassHandle asClass,
+                                                                    const char *expectedName )
 {
 	time_t startTime = this->getCurrentTime();
 	while( (*discovered)[objectHandle] == NULL )
@@ -1101,7 +1101,7 @@ void Test13FederateAmbassador::waitForOwnershipCancelConfirmation( RTI::ObjectHa
  * This method waits until a callback is delivered informing the federate that a save with the
  * given label is initiated. If no callback is received in time, the current test will be failed.
  */
-void Test13FederateAmbassador::waitForSaveInitiated( char *saveLabel )
+void Test13FederateAmbassador::waitForSaveInitiated( const char* saveLabel )
 {
 	time_t startTime = this->getCurrentTime();
 	while( this->currentSave->isInitiated(saveLabel) == RTI::RTI_FALSE )
@@ -1116,7 +1116,7 @@ void Test13FederateAmbassador::waitForSaveInitiated( char *saveLabel )
  * has been initiated occurs. It expects that one will not occur and should one be received before
  * a timeout has expired, the current test will be killed.
  */
-void Test13FederateAmbassador::waitForSaveInitiatedTimeout( char *saveLabel )
+void Test13FederateAmbassador::waitForSaveInitiatedTimeout( const char* saveLabel )
 {
 	time_t startTime = this->getCurrentTime();
 	while( currentSave->isInitiated(saveLabel) == RTI::RTI_FALSE )
@@ -1194,7 +1194,7 @@ void Test13FederateAmbassador::waitForFederationRestoreBegun()
  * Wait for a notification that a federation restore has been initiated with the given label.
  * If this happens, return the federation handle we were given. If not, throw an exception.
  */
-int Test13FederateAmbassador::waitForFederateRestoreInitiated( char* label )
+int Test13FederateAmbassador::waitForFederateRestoreInitiated( const char* label )
 {
 	// wait for something to come in for that object
 	time_t startTime = this->getCurrentTime();
@@ -1220,7 +1220,7 @@ int Test13FederateAmbassador::waitForFederateRestoreInitiated( char* label )
  * The opposite of waitForFederateRestoreInitiated(char*)}, this method expects a
  * timeout to occur and will fail the current test if one doesn't happen.
  */
-void Test13FederateAmbassador::waitForFederateRestoreInitiatedTimeout( char* saveLabel )
+void Test13FederateAmbassador::waitForFederateRestoreInitiatedTimeout( const char* saveLabel )
 {
 	time_t startTime = this->getCurrentTime();
 	while( currentRestore->isInitiated(saveLabel) == RTI::RTI_FALSE )
@@ -1264,7 +1264,7 @@ void Test13FederateAmbassador::waitForFederationRestored()
  * Like waitForFederationRestored() except that it expects a timeout and will fail the test if the
  * notification is received.
  */
-void Test13FederateAmbassador::waitForFederationRestoredTimeout( char* label )
+void Test13FederateAmbassador::waitForFederationRestoredTimeout( const char* label )
 {
 	time_t startTime = this->getCurrentTime();
 	while( currentRestore->isComplete() == RTI::RTI_FALSE )
@@ -1309,7 +1309,7 @@ void Test13FederateAmbassador::waitForFederationNotRestored()
  * label that they attempted to initiate was successful. If it doesn't happen in a timely
  * fashion, the current test is failed.
  */
-void Test13FederateAmbassador::waitForRestoreRequestSuccess( char *label )
+void Test13FederateAmbassador::waitForRestoreRequestSuccess( const char* label )
 {
 	time_t startTime = this->getCurrentTime();
 	while( successfulRestoreRequest != NULL && strcmp(successfulRestoreRequest,label) != 0 )
@@ -1324,7 +1324,7 @@ void Test13FederateAmbassador::waitForRestoreRequestSuccess( char *label )
  * label that they attempted to initiate has FAILED. If it doesn't happen in a timely fashion,
  * the current test is failed.
  */
-void Test13FederateAmbassador::waitForRestoreRequestFailure( char *label )
+void Test13FederateAmbassador::waitForRestoreRequestFailure( const char* label )
 {
 	time_t startTime = this->getCurrentTime();
 	while( failedRestoreRequest != NULL && strcmp(failedRestoreRequest,label) != 0 )

--- a/codebase/src/cpp/hla13/test/common/Test13FederateAmbassador.h
+++ b/codebase/src/cpp/hla13/test/common/Test13FederateAmbassador.h
@@ -35,7 +35,7 @@ class ActiveSR;
 //////////////////////////////////////////
 struct ltstr
 {
-	bool operator() ( char* s1, char* s2 ) const
+	bool operator() ( const char* s1, const char* s2 ) const
 	{
 		return strcmp(s1, s2) < 0;
 	}
@@ -71,12 +71,12 @@ class Test13FederateAmbassador : public NullFederateAmbassador
 
 	public: // were "protected" in Java version as that really means "package", make them
 		    // public here just to make for easier access
-		RTI::Boolean               constrained;
-		RTI::Boolean               regulating;
-		double                     logicalTime;
-		map<char*, char*, ltstr>   *announced;
-		set<char*, ltstr>          *synchronized;
-		SyncRegResult              syncRegResult;
+		RTI::Boolean                            constrained;
+		RTI::Boolean                            regulating;
+		double                                  logicalTime;
+		map<const char*, const char*, ltstr>    *announced;
+		set<const char*, ltstr>                 *synchronized;
+		SyncRegResult                           syncRegResult;
 		
 		// object/interaction containers
 		map<RTI::ObjectHandle,Test13Object*> *discovered;
@@ -101,8 +101,8 @@ class Test13FederateAmbassador : public NullFederateAmbassador
 		// save/restore stuff
 		ActiveSR *currentSave;
 		ActiveSR *currentRestore;
-		char *successfulRestoreRequest;
-		char *failedRestoreRequest;
+		char* successfulRestoreRequest;
+		char* failedRestoreRequest;
 
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
@@ -120,7 +120,7 @@ class Test13FederateAmbassador : public NullFederateAmbassador
 	private:
 		void         tick();
 		time_t       getCurrentTime();
-		void         checkTimeout( time_t startTime, char *currentMethod );
+		void         checkTimeout( time_t startTime, const char* currentMethod );
 		RTI::Boolean checkTimeoutNonFatal( time_t startTime );
 	
 		// helper methods
@@ -133,18 +133,18 @@ class Test13FederateAmbassador : public NullFederateAmbassador
 		
 		/** does a string copy from source to target, but will delete the memory at target
 		    is it isn't null and will allocate new memory. Really just a "cleanAndCopy" */
-		void copyString( char *target, const char *source );
+		void copyString( char* target, const char* source );
 		
 	public:
 		// synchronization point methods
-		RTI::Boolean isAnnounced( char* label );
-		RTI::Boolean isSynchronized( char* label );
-		char*        waitForSyncAnnounce( char* label );
-		void         waitForSyncAnnounceTimeout( char* label );
-		RTI::Boolean waitForSyncRegResult( char* label );
-		void         waitForSyncRegResult( char* label, RTI::Boolean expectedResult );
-		void         waitForSynchronized( char* label );
-		void         waitForSynchornizedTimeout( char* label );
+		RTI::Boolean isAnnounced( const char* label );
+		RTI::Boolean isSynchronized( const char* label );
+		const char*  waitForSyncAnnounce( const char* label );
+		void         waitForSyncAnnounceTimeout( const char* label );
+		RTI::Boolean waitForSyncRegResult( const char* label );
+		void         waitForSyncRegResult( const char* label, RTI::Boolean expectedResult );
+		void         waitForSynchronized( const char* label );
+		void         waitForSynchornizedTimeout( const char* label );
 		
 		// logical time management methods
 		void         waitForConstrainedEnabled();
@@ -156,8 +156,8 @@ class Test13FederateAmbassador : public NullFederateAmbassador
 		Test13Object* waitForDiscovery( RTI::ObjectHandle objectHandle );
 		Test13Object* waitForDiscoveryAs( RTI::ObjectHandle object, RTI::ObjectClassHandle asClass );
 		Test13Object* waitForDiscoveryAsWithName( RTI::ObjectHandle object,
-		                                           RTI::ObjectClassHandle asClass,
-		                                           char *expectedName );
+		                                          RTI::ObjectClassHandle asClass,
+		                                          const char* expectedName );
 		void         waitForDiscoveryTimeout( RTI::ObjectHandle objectHandle );
 		
 		// remove
@@ -193,19 +193,19 @@ class Test13FederateAmbassador : public NullFederateAmbassador
 		void waitForOwnershipCancelConfirmation( RTI::ObjectHandle object, int attributes, ... );
 		
 		// save restore
-		void waitForSaveInitiated( char *saveLabel );
-		void waitForSaveInitiatedTimeout( char *saveLabel );
+		void waitForSaveInitiated( const char* saveLabel );
+		void waitForSaveInitiatedTimeout( const char* saveLabel );
 		void waitForFederationSaved();
 		void waitForFederationNotSaved();
 		
 		void waitForFederationRestoreBegun();
-		int waitForFederateRestoreInitiated( char* label );
-		void waitForFederateRestoreInitiatedTimeout( char* label );
+		int waitForFederateRestoreInitiated( const char* label );
+		void waitForFederateRestoreInitiatedTimeout( const char* label );
 		void waitForFederationRestored();
-		void waitForFederationRestoredTimeout( char* label );
+		void waitForFederationRestoredTimeout( const char* label );
 		void waitForFederationNotRestored();
-		void waitForRestoreRequestSuccess( char *label );
-		void waitForRestoreRequestFailure( char *label );
+		void waitForRestoreRequestSuccess( const char* label );
+		void waitForRestoreRequestFailure( const char* label );
 		
 	//////////////////////////////////////////////////////////////////////////////////////////
 	/////////////////////////////// FederateAmbassador Methods ///////////////////////////////
@@ -220,37 +220,37 @@ class Test13FederateAmbassador : public NullFederateAmbassador
 		////////////////////////////////////////////
 		///// Synchornization Point Management /////
 		////////////////////////////////////////////
-		virtual void synchronizationPointRegistrationSucceeded( const char *label )
+		virtual void synchronizationPointRegistrationSucceeded( const char* label )
 			throw( RTI::FederateInternalError );
 	
-		virtual void synchronizationPointRegistrationFailed( const char *label )
+		virtual void synchronizationPointRegistrationFailed( const char* label )
 			throw( RTI::FederateInternalError );
 	
-		virtual void announceSynchronizationPoint( const char *label, const char *tag )
+		virtual void announceSynchronizationPoint( const char* label, const char* tag )
 			throw( RTI::FederateInternalError );
 	
-		virtual void federationSynchronized( const char *label )
+		virtual void federationSynchronized( const char* label )
 			throw( RTI::FederateInternalError );
 	
 		///////////////////////////////////////
 		///// Save and Restore Management /////
 		///////////////////////////////////////
-		virtual void initiateFederateSave( const char *label )
+		virtual void initiateFederateSave( const char* label )
 			throw( RTI::UnableToPerformSave, RTI::FederateInternalError );
 	
 		virtual void federationSaved() throw( RTI::FederateInternalError );
 	
 		virtual void federationNotSaved() throw( RTI::FederateInternalError );
 	
-		virtual void requestFederationRestoreSucceeded( const char *label )
+		virtual void requestFederationRestoreSucceeded( const char* label )
 			throw( RTI::FederateInternalError );
 	
-		virtual void requestFederationRestoreFailed( const char *label, const char *reason )
+		virtual void requestFederationRestoreFailed( const char* label, const char* reason )
 			throw( RTI::FederateInternalError );
 	
 		virtual void federationRestoreBegun() throw( RTI::FederateInternalError );
 	
-		virtual void initiateFederateRestore( const char *label, RTI::FederateHandle handle )
+		virtual void initiateFederateRestore( const char* label, RTI::FederateHandle handle )
 			throw( RTI::SpecifiedSaveLabelDoesNotExist,
 			       RTI::CouldNotRestore,
 			       RTI::FederateInternalError );
@@ -286,7 +286,7 @@ class Test13FederateAmbassador : public NullFederateAmbassador
 		virtual void reflectAttributeValues( RTI::ObjectHandle theObject,
 		                                     const RTI::AttributeHandleValuePairSet& theAttributes,
 		                                     const RTI::FedTime& theTime,
-		                                     const char *theTag,
+		                                     const char* theTag,
 		                                     RTI::EventRetractionHandle theHandle )
 			throw( RTI::ObjectNotKnown,
 			       RTI::AttributeNotKnown,
@@ -296,7 +296,7 @@ class Test13FederateAmbassador : public NullFederateAmbassador
 	
 		virtual void reflectAttributeValues( RTI::ObjectHandle theObject,
 		                                     const RTI::AttributeHandleValuePairSet& theAttributes,
-		                                     const char *theTag )
+		                                     const char* theTag )
 			throw( RTI::ObjectNotKnown,
 			       RTI::AttributeNotKnown,
 			       RTI::FederateOwnsAttributes,
@@ -305,7 +305,7 @@ class Test13FederateAmbassador : public NullFederateAmbassador
 		virtual void receiveInteraction( RTI::InteractionClassHandle theInteraction,
 		                                 const RTI::ParameterHandleValuePairSet& theParameters,
 		                                 const RTI::FedTime& theTime,
-		                                 const char *theTag,
+		                                 const char* theTag,
 		                                 RTI::EventRetractionHandle theHandle )
 			throw( RTI::InteractionClassNotKnown,
 			       RTI::InteractionParameterNotKnown,
@@ -314,20 +314,20 @@ class Test13FederateAmbassador : public NullFederateAmbassador
 	
 		virtual void receiveInteraction( RTI::InteractionClassHandle theInteraction,
 		                                const RTI::ParameterHandleValuePairSet& theParameters,
-		                                const char *theTag )
+		                                const char* theTag )
 			throw( RTI::InteractionClassNotKnown,
 			       RTI::InteractionParameterNotKnown,
 			       RTI::FederateInternalError );
 	
 		virtual void removeObjectInstance( RTI::ObjectHandle theObject,
 		                                   const RTI::FedTime& theTime,
-		                                   const char *theTag,
+		                                   const char* theTag,
 		                                   RTI::EventRetractionHandle theHandle )
 			throw( RTI::ObjectNotKnown,
 			       RTI::InvalidFederationTime,
 			       RTI::FederateInternalError );
 	
-		virtual void removeObjectInstance( RTI::ObjectHandle theObject, const char *theTag )
+		virtual void removeObjectInstance( RTI::ObjectHandle theObject, const char* theTag )
 			throw( RTI::ObjectNotKnown, RTI::FederateInternalError );
 	
 		virtual void attributesInScope( RTI::ObjectHandle theObject,
@@ -367,7 +367,7 @@ class Test13FederateAmbassador : public NullFederateAmbassador
 	
 		virtual void requestAttributeOwnershipAssumption( RTI::ObjectHandle theObject,
 		                                                  const RTI::AttributeHandleSet& offered,
-		                                                  const char *theTag )
+		                                                  const char* theTag )
 			throw( RTI::ObjectNotKnown,
 			       RTI::AttributeNotKnown,
 			       RTI::AttributeAlreadyOwned,
@@ -403,7 +403,7 @@ class Test13FederateAmbassador : public NullFederateAmbassador
 	
 		virtual void requestAttributeOwnershipRelease( RTI::ObjectHandle theObject,
 		                                               const RTI::AttributeHandleSet& candidates,
-		                                               const char *theTag )
+		                                               const char* theTag )
 			throw( RTI::ObjectNotKnown,
 			       RTI::AttributeNotKnown,
 			       RTI::AttributeNotOwned,

--- a/codebase/src/cpp/hla13/test/saverestore/FederationRestoreTest.cpp
+++ b/codebase/src/cpp/hla13/test/saverestore/FederationRestoreTest.cpp
@@ -20,13 +20,17 @@ CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( FederationRestoreTest, "FederationRestore
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( FederationRestoreTest, "SaveRestore" );
 
 /////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////// Static Variables /////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////
+const char* FederationRestoreTest::SAVE_LABEL = "FederationSaveTest";
+
+/////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////// Constructors/Destructors /////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////
 FederationRestoreTest::FederationRestoreTest()
 {
 	this->defaultFederate = new Test13Federate( "defaultFederate" );
 	this->secondFederate = new Test13Federate( "secondFederate" );
-	this->saveLabel = "FederationSaveTest";
 }
 
 FederationRestoreTest::~FederationRestoreTest()
@@ -45,7 +49,7 @@ void FederationRestoreTest::setUp()
 	this->defaultFederate->quickJoin();
 	this->secondFederate->quickJoin();
 	
-	defaultFederate->quickSaveToCompletion( saveLabel, 2, defaultFederate, secondFederate );
+	defaultFederate->quickSaveToCompletion( SAVE_LABEL, 2, defaultFederate, secondFederate );
 }
 
 void FederationRestoreTest::tearDown()
@@ -66,14 +70,14 @@ void FederationRestoreTest::testRequestFederationRestore()
 {
 	try
 	{
-		defaultFederate->rtiamb->requestFederationRestore( saveLabel );
+		defaultFederate->rtiamb->requestFederationRestore( SAVE_LABEL );
 	}
 	catch( RTI::Exception& e )
 	{
 		failTest( "Unexpected exception while requesting federation restore: %s", e._reason );
 	}
 	
-	defaultFederate->fedamb->waitForRestoreRequestSuccess( saveLabel );
+	defaultFederate->fedamb->waitForRestoreRequestSuccess( SAVE_LABEL );
 }
 
 ///////////////////////////////////////////////////////
@@ -84,7 +88,7 @@ void FederationRestoreTest::testRequestFederationRestoreWhenNotJoined()
 	defaultFederate->quickResign();
 	try
 	{
-		defaultFederate->rtiamb->requestFederationRestore( saveLabel );
+		defaultFederate->rtiamb->requestFederationRestore( SAVE_LABEL );
 		failTestMissingException( "FederateNotExecutionMember",
 		                          "requesting federation restore when not joined" );
 	}
@@ -104,10 +108,10 @@ void FederationRestoreTest::testRequestFederationRestoreWhenNotJoined()
 ////////////////////////////////////////////////////////////
 void FederationRestoreTest::testRequestFederationRestoreWhenSaveInProgress()
 {
-	defaultFederate->quickSaveInProgress( saveLabel );
+	defaultFederate->quickSaveInProgress( SAVE_LABEL );
 	try
 	{
-		defaultFederate->rtiamb->requestFederationRestore( saveLabel );
+		defaultFederate->rtiamb->requestFederationRestore( SAVE_LABEL );
 		failTestMissingException( "SaveInProgress",
 		                          "requesting federation restore when save in progress" );
 	}
@@ -127,10 +131,10 @@ void FederationRestoreTest::testRequestFederationRestoreWhenSaveInProgress()
 ///////////////////////////////////////////////////////////////
 void FederationRestoreTest::testRequestFederationRestoreWhenRestoreInProgress()
 {
-	defaultFederate->quickRestoreInProgress( saveLabel, 2, defaultFederate, secondFederate );
+	defaultFederate->quickRestoreInProgress( SAVE_LABEL, 2, defaultFederate, secondFederate );
 	try
 	{
-		defaultFederate->rtiamb->requestFederationRestore( saveLabel );
+		defaultFederate->rtiamb->requestFederationRestore( SAVE_LABEL );
 		failTestMissingException( "RestoreInProgress",
 		                          "requesting federation restore when restore in progress" );
 	}
@@ -155,12 +159,12 @@ void FederationRestoreTest::testRequestFederationRestoreWhenRestoreInProgress()
 ///////////////////////////////////////////////////
 void FederationRestoreTest::testFederationRestoreComplete()
 {
-	defaultFederate->quickRestoreRequest( saveLabel );
-	defaultFederate->fedamb->waitForRestoreRequestSuccess( saveLabel );
+	defaultFederate->quickRestoreRequest( SAVE_LABEL );
+	defaultFederate->fedamb->waitForRestoreRequestSuccess( SAVE_LABEL );
 	defaultFederate->fedamb->waitForFederationRestoreBegun();
 	secondFederate->fedamb->waitForFederationRestoreBegun();
-	defaultFederate->fedamb->waitForFederateRestoreInitiated( saveLabel );
-	secondFederate->fedamb->waitForFederateRestoreInitiated( saveLabel );
+	defaultFederate->fedamb->waitForFederateRestoreInitiated( SAVE_LABEL );
+	secondFederate->fedamb->waitForFederateRestoreInitiated( SAVE_LABEL );
 	
 	try
 	{
@@ -226,7 +230,7 @@ void FederationRestoreTest::testFederationRestoreCompleteWhenNotJoined()
 /////////////////////////////////////////////////////////////
 void FederationRestoreTest::testFederationRestoreCompleteWhenSaveInProgress()
 {
-	defaultFederate->quickSaveInProgress( saveLabel );
+	defaultFederate->quickSaveInProgress( SAVE_LABEL );
 	try
 	{
 		defaultFederate->rtiamb->federateRestoreComplete();
@@ -253,12 +257,12 @@ void FederationRestoreTest::testFederationRestoreCompleteWhenSaveInProgress()
 //////////////////////////////////////////////////////
 void FederationRestoreTest::testFederationRestoreNotComplete()
 {
-	defaultFederate->quickRestoreRequest( saveLabel );
-	defaultFederate->fedamb->waitForRestoreRequestSuccess( saveLabel );
+	defaultFederate->quickRestoreRequest( SAVE_LABEL );
+	defaultFederate->fedamb->waitForRestoreRequestSuccess( SAVE_LABEL );
 	defaultFederate->fedamb->waitForFederationRestoreBegun();
 	secondFederate->fedamb->waitForFederationRestoreBegun();
-	defaultFederate->fedamb->waitForFederateRestoreInitiated( saveLabel );
-	secondFederate->fedamb->waitForFederateRestoreInitiated( saveLabel );
+	defaultFederate->fedamb->waitForFederateRestoreInitiated( SAVE_LABEL );
+	secondFederate->fedamb->waitForFederateRestoreInitiated( SAVE_LABEL );
 	defaultFederate->quickRestoreComplete();
 	
 	try
@@ -324,7 +328,7 @@ void FederationRestoreTest::testFederationRestoreNotCompleteWhenNotJoined()
 ////////////////////////////////////////////////////////////////
 void FederationRestoreTest::testFederationRestoreNotCompleteWhenSaveInProgress()
 {
-	defaultFederate->quickSaveInProgress( saveLabel );
+	defaultFederate->quickSaveInProgress( SAVE_LABEL );
 	try
 	{
 		defaultFederate->rtiamb->federateRestoreNotComplete();

--- a/codebase/src/cpp/hla13/test/saverestore/FederationRestoreTest.h
+++ b/codebase/src/cpp/hla13/test/saverestore/FederationRestoreTest.h
@@ -19,6 +19,8 @@ class FederationRestoreTest : public CppUnit::TestFixture
 	//----------------------------------------------------------
 	//                    STATIC VARIABLES
 	//----------------------------------------------------------
+	private:
+		static const char* SAVE_LABEL;
 
 	//----------------------------------------------------------
 	//                   INSTANCE VARIABLES
@@ -26,7 +28,6 @@ class FederationRestoreTest : public CppUnit::TestFixture
 	private:
 		Test13Federate *defaultFederate;
 		Test13Federate *secondFederate;
-		char *saveLabel;
 
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS

--- a/codebase/src/cpp/hla13/test/saverestore/FederationSaveTest.cpp
+++ b/codebase/src/cpp/hla13/test/saverestore/FederationSaveTest.cpp
@@ -20,13 +20,17 @@ CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( FederationSaveTest, "FederationSaveTest" 
 CPPUNIT_TEST_SUITE_NAMED_REGISTRATION( FederationSaveTest, "SaveRestore" );
 
 /////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////// Static Variables /////////////////////////////////////
+/////////////////////////////////////////////////////////////////////////////////////////////
+const char* FederationSaveTest::SAVE_LABEL = "FederationSaveTest";
+
+/////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////// Constructors/Destructors /////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////////////////
 FederationSaveTest::FederationSaveTest()
 {
 	this->defaultFederate = new Test13Federate( "defaultFederate" );
 	this->secondFederate = new Test13Federate( "secondFederate" );
-	this->saveLabel = "FederationSaveTest";
 }
 
 FederationSaveTest::~FederationSaveTest()
@@ -78,7 +82,7 @@ void FederationSaveTest::testRequestFederationSave()
 {
 	try
 	{
-		defaultFederate->rtiamb->requestFederationSave( saveLabel );
+		defaultFederate->rtiamb->requestFederationSave( SAVE_LABEL );
 	}
 	catch( RTI::Exception& e )
 	{
@@ -86,8 +90,8 @@ void FederationSaveTest::testRequestFederationSave()
 	}
 
 	// make sure the proper callbacks are sent out
-	defaultFederate->fedamb->waitForSaveInitiated( saveLabel );
-	secondFederate->fedamb->waitForSaveInitiated( saveLabel );
+	defaultFederate->fedamb->waitForSaveInitiated( SAVE_LABEL );
+	secondFederate->fedamb->waitForSaveInitiated( SAVE_LABEL );
 }
 
 ////////////////////////////////////////////////////
@@ -98,7 +102,7 @@ void FederationSaveTest::testRequestFederationSaveWhenNotJoined()
 	defaultFederate->quickResign();
 	try
 	{
-		defaultFederate->rtiamb->requestFederationSave( this->saveLabel );
+		defaultFederate->rtiamb->requestFederationSave( SAVE_LABEL );
 		failTestMissingException( "FederateNotExecutionMember",
 		                          "requesting federation save when not joined" );
 	}
@@ -118,7 +122,7 @@ void FederationSaveTest::testRequestFederationSaveWhenNotJoined()
 /////////////////////////////////////////////////////////
 void FederationSaveTest::testRequestFederationSaveWhenSaveInProgress()
 {
-	defaultFederate->quickSaveInProgress( saveLabel );
+	defaultFederate->quickSaveInProgress( SAVE_LABEL );
 	try
 	{
 		defaultFederate->rtiamb->requestFederationSave( "otherLabel" );
@@ -139,10 +143,10 @@ void FederationSaveTest::testRequestFederationSaveWhenSaveInProgress()
 ////////////////////////////////////////////////////////////
 void FederationSaveTest::testRequestFederationSaveWhenRestoreInProgress()
 {
-	defaultFederate->quickRestoreInProgress( saveLabel, 2, defaultFederate, secondFederate );
+	defaultFederate->quickRestoreInProgress( SAVE_LABEL, 2, defaultFederate, secondFederate );
 	try
 	{
-		defaultFederate->rtiamb->requestFederationSave( saveLabel );
+		defaultFederate->rtiamb->requestFederationSave( SAVE_LABEL );
 		failTestMissingException( "RestoreInProgress", "requesting save while restore in progress" );
 	}
 	catch( RTI::RestoreInProgress& rip )
@@ -167,7 +171,7 @@ void FederationSaveTest::testTimestampedRequestFederationSave()
 	try
 	{
 		RTIfedTime time = 10.0;
-		defaultFederate->rtiamb->requestFederationSave( saveLabel, time );
+		defaultFederate->rtiamb->requestFederationSave( SAVE_LABEL, time );
 	}
 	catch( RTI::Exception& e )
 	{
@@ -175,8 +179,8 @@ void FederationSaveTest::testTimestampedRequestFederationSave()
 	}
 	
 	// we shouldn't get any callbacks yet, as neither federate is at 10.0
-	defaultFederate->fedamb->waitForSaveInitiatedTimeout( saveLabel );
-	secondFederate->fedamb->waitForSaveInitiatedTimeout( saveLabel );
+	defaultFederate->fedamb->waitForSaveInitiatedTimeout( SAVE_LABEL );
+	secondFederate->fedamb->waitForSaveInitiatedTimeout( SAVE_LABEL );
 
 	// advance the federates to 10.0
 	defaultFederate->quickAdvanceRequest( 10.0 );
@@ -184,8 +188,8 @@ void FederationSaveTest::testTimestampedRequestFederationSave()
 	defaultFederate->fedamb->waitForTimeAdvance( 10.0 );
 
 	// now we should get the save notification
-	defaultFederate->fedamb->waitForSaveInitiated( saveLabel );
-	secondFederate->fedamb->waitForSaveInitiated( saveLabel );
+	defaultFederate->fedamb->waitForSaveInitiated( SAVE_LABEL );
+	secondFederate->fedamb->waitForSaveInitiated( SAVE_LABEL );
 }
 
 ////////////////////////////////////////////////////////////////
@@ -196,7 +200,7 @@ void FederationSaveTest::testTimestampedRequestFederationSaveWithTimeInPast()
 	try
 	{
 		RTIfedTime theTime = 1.0;
-		defaultFederate->rtiamb->requestFederationSave( this->saveLabel, theTime );
+		defaultFederate->rtiamb->requestFederationSave( SAVE_LABEL, theTime );
 		failTestMissingException( "FederateNotExecutionMember",
 		                          "requesting federation save with time in past" );
 	}
@@ -220,7 +224,7 @@ void FederationSaveTest::testTimestampedRequestFederationSaveWhenNotJoined()
 	try
 	{
 		RTIfedTime theTime = 10.0;
-		defaultFederate->rtiamb->requestFederationSave( this->saveLabel, theTime );
+		defaultFederate->rtiamb->requestFederationSave( SAVE_LABEL, theTime );
 		failTestMissingException( "FederateNotExecutionMember",
 		                          "requesting federation save when not joined" );
 	}
@@ -240,11 +244,11 @@ void FederationSaveTest::testTimestampedRequestFederationSaveWhenNotJoined()
 ////////////////////////////////////////////////////////////////////
 void FederationSaveTest::testTimestampedRequestFederationSaveWhenSaveInProgress()
 {
-	defaultFederate->quickSaveInProgress( saveLabel );
+	defaultFederate->quickSaveInProgress( SAVE_LABEL );
 	try
 	{
 		RTIfedTime time = 10.0;
-		defaultFederate->rtiamb->requestFederationSave( saveLabel, time );
+		defaultFederate->rtiamb->requestFederationSave( SAVE_LABEL, time );
 		failTestMissingException( "SaveInProgress",
 		                          "requesting timestampped save while save in progress" );
 	}
@@ -264,11 +268,11 @@ void FederationSaveTest::testTimestampedRequestFederationSaveWhenSaveInProgress(
 ///////////////////////////////////////////////////////////////////////
 void FederationSaveTest::testTimestampedRequestFederationSaveWhenRestoreInProgress()
 {
-	defaultFederate->quickRestoreInProgress( saveLabel, 2, defaultFederate, secondFederate );
+	defaultFederate->quickRestoreInProgress( SAVE_LABEL, 2, defaultFederate, secondFederate );
 	try
 	{
 		RTIfedTime time = 100.0;
-		defaultFederate->rtiamb->requestFederationSave( saveLabel, time );
+		defaultFederate->rtiamb->requestFederationSave( SAVE_LABEL, time );
 		failTestMissingException( "RestoreInProgress",
 		                          "requesting timestamped save while restore in progress" );
 	}
@@ -292,9 +296,9 @@ void FederationSaveTest::testTimestampedRequestFederationSaveWhenRestoreInProgre
 ///////////////////////////////////////////
 void FederationSaveTest::testFederateSaveBegun()
 {
-	defaultFederate->quickSaveRequest( saveLabel );
-	defaultFederate->fedamb->waitForSaveInitiated( saveLabel );
-	secondFederate->fedamb->waitForSaveInitiated( saveLabel );
+	defaultFederate->quickSaveRequest( SAVE_LABEL );
+	defaultFederate->fedamb->waitForSaveInitiated( SAVE_LABEL );
+	secondFederate->fedamb->waitForSaveInitiated( SAVE_LABEL );
 	
 	try
 	{
@@ -358,7 +362,7 @@ void FederationSaveTest::testFederateSaveBegunWhenNotJoined()
 ////////////////////////////////////////////////////////
 void FederationSaveTest::testFederateSaveBegunWhenRestoreInProgress()
 {
-	defaultFederate->quickRestoreInProgress( saveLabel, 2, defaultFederate, secondFederate );
+	defaultFederate->quickRestoreInProgress( SAVE_LABEL, 2, defaultFederate, secondFederate );
 	try
 	{
 		defaultFederate->rtiamb->federateSaveBegun();
@@ -385,9 +389,9 @@ void FederationSaveTest::testFederateSaveBegunWhenRestoreInProgress()
 //////////////////////////////////////////////
 void FederationSaveTest::testFederateSaveComplete()
 {
-	defaultFederate->quickSaveRequest( saveLabel );
-	defaultFederate->fedamb->waitForSaveInitiated( saveLabel );
-	secondFederate->fedamb->waitForSaveInitiated( saveLabel );
+	defaultFederate->quickSaveRequest( SAVE_LABEL );
+	defaultFederate->fedamb->waitForSaveInitiated( SAVE_LABEL );
+	secondFederate->fedamb->waitForSaveInitiated( SAVE_LABEL );
 	defaultFederate->quickSaveBegun();
 	secondFederate->quickSaveBegun();
 	
@@ -455,7 +459,7 @@ void FederationSaveTest::testFederateSaveCompleteWhenNotJoined()
 ///////////////////////////////////////////////////////////
 void FederationSaveTest::testFederateSaveCompleteWhenRestoreInProgress()
 {
-	defaultFederate->quickRestoreInProgress( saveLabel, 2, defaultFederate, secondFederate );
+	defaultFederate->quickRestoreInProgress( SAVE_LABEL, 2, defaultFederate, secondFederate );
 	try
 	{
 		defaultFederate->rtiamb->federateSaveComplete();
@@ -482,9 +486,9 @@ void FederationSaveTest::testFederateSaveCompleteWhenRestoreInProgress()
 //////////////////////////////////////////////////
 void FederationSaveTest::testFederateSaveNotCompleted()
 {
-	defaultFederate->quickSaveRequest( saveLabel );
-	defaultFederate->fedamb->waitForSaveInitiated( saveLabel );
-	secondFederate->fedamb->waitForSaveInitiated( saveLabel );
+	defaultFederate->quickSaveRequest( SAVE_LABEL );
+	defaultFederate->fedamb->waitForSaveInitiated( SAVE_LABEL );
+	secondFederate->fedamb->waitForSaveInitiated( SAVE_LABEL );
 	defaultFederate->quickSaveBegun();
 	secondFederate->quickSaveBegun();
 	defaultFederate->quickSaveComplete();
@@ -553,7 +557,7 @@ void FederationSaveTest::testFederateSaveNotCompletedWhenNotJoined()
 ///////////////////////////////////////////////////////////////
 void FederationSaveTest::testFederateSaveNotCompletedWhenRestoreInProgress()
 {
-	defaultFederate->quickRestoreInProgress( saveLabel, 2, defaultFederate, secondFederate );
+	defaultFederate->quickRestoreInProgress( SAVE_LABEL, 2, defaultFederate, secondFederate );
 	try
 	{
 		defaultFederate->rtiamb->federateSaveNotComplete();

--- a/codebase/src/cpp/hla13/test/saverestore/FederationSaveTest.h
+++ b/codebase/src/cpp/hla13/test/saverestore/FederationSaveTest.h
@@ -19,6 +19,8 @@ class FederationSaveTest : public CppUnit::TestFixture
 	//----------------------------------------------------------
 	//                    STATIC VARIABLES
 	//----------------------------------------------------------
+	private:
+		static const char* SAVE_LABEL;
 
 	//----------------------------------------------------------
 	//                   INSTANCE VARIABLES
@@ -26,7 +28,6 @@ class FederationSaveTest : public CppUnit::TestFixture
 	private:
 		Test13Federate *defaultFederate;
 		Test13Federate *secondFederate;
-		char *saveLabel;
 
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS

--- a/codebase/src/cpp/hla13/test/synchronization/RegisterSyncPointTest.cpp
+++ b/codebase/src/cpp/hla13/test/synchronization/RegisterSyncPointTest.cpp
@@ -121,7 +121,7 @@ void RegisterSyncPointTest::testRegisterSyncPointWithNullTag()
 	
 	// make sure the registration is a success
 	federateOne->fedamb->waitForSyncRegResult( label, RTI::RTI_TRUE );
-	char *incomingTag = federateTwo->fedamb->waitForSyncAnnounce( label );
+	const char *incomingTag = federateTwo->fedamb->waitForSyncAnnounce( label );
 	if( incomingTag != NULL )
 		failTest( "Expected sync point announcement tag to be NULL, but was [%s]", incomingTag );
 }
@@ -143,7 +143,7 @@ void RegisterSyncPointTest::testRegisterSyncPointWithEmptyTag()
 	
 	// make sure the registration is a success
 	federateOne->fedamb->waitForSyncRegResult( label, RTI::RTI_TRUE );
-	char *incomingTag = federateTwo->fedamb->waitForSyncAnnounce( label );
+	const char *incomingTag = federateTwo->fedamb->waitForSyncAnnounce( label );
 	if( incomingTag == NULL || strcmp("", incomingTag) != 0 )
 		failTest( "Expected sync point announcement tag to be \"\", but was [%s]", incomingTag );
 }
@@ -165,7 +165,7 @@ void RegisterSyncPointTest::testRegisterSyncPointWithWhitespaceTag()
 	
 	// make sure the registration is a success
 	federateOne->fedamb->waitForSyncRegResult( label, RTI::RTI_TRUE );
-	char *incomingTag = federateTwo->fedamb->waitForSyncAnnounce( label );
+	const char *incomingTag = federateTwo->fedamb->waitForSyncAnnounce( label );
 	if( incomingTag == NULL || strcmp("   ", incomingTag) != 0 )
 		failTest( "Expected sync point announcement tag to be \"   \", but was [%s]", incomingTag );
 }

--- a/codebase/src/cpp/hla13/test/types/AttributeHandleValuePairSetTest.cpp
+++ b/codebase/src/cpp/hla13/test/types/AttributeHandleValuePairSetTest.cpp
@@ -246,9 +246,9 @@ void AttributeHandleValuePairSetTest::testGetValueWithInvalidIndex()
 /////////////////////////////////////////
 void AttributeHandleValuePairSetTest::testGetValuePointer()
 {
-	char *aaValue = "one";
-	char *abValue = "two";
-	char *acValue = "three";
+	const char *aaValue = "one";
+	const char *abValue = "two";
+	const char *acValue = "three";
 	this->theSet->add( 501, aaValue, 4 );
 	this->theSet->add( 502, abValue, 4 );
 	this->theSet->add( 503, acValue, 6 );

--- a/codebase/src/cpp/hla13/test/types/ParameterHandleValuePairSetTest.cpp
+++ b/codebase/src/cpp/hla13/test/types/ParameterHandleValuePairSetTest.cpp
@@ -246,9 +246,9 @@ void ParameterHandleValuePairSetTest::testGetValueWithInvalidIndex()
 /////////////////////////////////////////
 void ParameterHandleValuePairSetTest::testGetValuePointer()
 {
-	char *aaValue = "one";
-	char *abValue = "two";
-	char *acValue = "three";
+	const char *aaValue = "one";
+	const char *abValue = "two";
+	const char *acValue = "three";
 	this->theSet->add( 501, aaValue, 4 );
 	this->theSet->add( 502, abValue, 4 );
 	this->theSet->add( 503, acValue, 6 );


### PR DESCRIPTION
This PR has been raised in response to https://github.com/openlvc/portico/issues/99

## Cause
The warnings were being generated on OSX due to clang's adherance to the c++11 standard. C++11 has deprecated the assignment of a non-const char* variable to a string literal

## Work Completed
- char* params in all test related functions have been analysed and converted to const char* where appropriate
- The `MAP_LTSTR_CLEANUP` macro in Common.h has been modified to work with a `map<const char*,const char*>`
- The `SET_LTSTR_CLEANUP` in Common.h has been modified to work with a `set<const char*>`
- Modified `Test13Federate::quickReflectFai`l to handle situation where the provided const char* tag parameter is `NULL`
- Modified `Test13Federate::quickSendFail` to handle situation where the provided const char* tag parameter is `NULL`
- `Test13Federate::announced` member is now a map<const char*,const char*>
- `Test13Federate::synchronized` member is now a set<const char*>
- The char* `FederationRestoreTest::saveLabel` member variable has been changed to a static const char* variable
- The char* `FederationSaveTest::saveLabel` member variable has been changed to a static const char* variable
- HLA13 and Test13 profiles have been modified so that the C++11 deprecated string conversion compiler warning is no longer disabled when compiling code

## Testing and Verification
- I have compiled this on OSX and no more `no-c++11-compat-deprecated-writable-strings` are appearing.
- I have compiled and run the tests under Windows and they are all passing still. No crashes witnessed!

## Other Notes
Running the ant target `cpp.test13.compile` under OSX still gives the following warnings:

```
In file included from /Users/michaelfraser/Documents/dev/workspace/portico/codebase/src/cpp/hla13/src/jni/Runtime.cpp:15:
/Users/michaelfraser/Documents/dev/workspace/portico/codebase/src/cpp/hla13/src/jni/Runtime.h:50:8: warning: private field 'jniCheck' is not used [-Wunused-private-field]
                 bool jniCheck;
```

and 

```
/Users/michaelfraser/Documents/dev/workspace/portico/codebase/src/cpp/hla13/test/common/Test13Federate.cpp:242:3: warning: delete called on 'RTI::FederateHandleSet' that is abstract but has non-virtual destructor [-Wdelete-non-virtual-dtor]
                 delete handleSet;
```
The latter warning refers to a class provided by the standard specification itself, so there's not much we can do about that! It looks to have been fixed in the dlc13 headers though.