### PR TITLE
PORT-124 hla13 tests dont compile under Windows

### DIFF
--- a/codebase/profiles/windows/hla13.xml
+++ b/codebase/profiles/windows/hla13.xml
@@ -144,7 +144,7 @@
 	<!-- ==================================== -->
 	<!--          HLA 1.3 Test Suite          -->
 	<!-- ==================================== -->
-	<target name="test" extensionOf="cpp.test" depends="java.sandbox,test.compile" if="disabled">
+	<target name="test" extensionOf="cpp.test" depends="java.sandbox,test.compile">
 		<!-- 1. copy the testing resources into test dir (RID file etc...) -->
 		<copy todir="${test13.complete.dir}">
 			<fileset dir="${resources.testdata.dir}/cpptest/hla13" includes="**/*"/>
@@ -162,7 +162,7 @@
 		      resultproperty="test13.result">
 			<arg value="${test13.complete.dir}\test-results.xml"/>
 			<env key="RTI_HOME" path="."/><!-- required, but we set the env up properly anyway -->
-			<env key="PATH" path="${hla13.complete.dir};${jdk.home.win32}\jre\bin\client"/>
+			<env key="PATH" path="${hla13.complete.dir}\vc10;${jdk.home.win32}\jre\bin\client"/>
 			<env key="PORTICO_DEBUG" value="OFF"/>
 			<env key="CLASSPATH" path="${sandbox.lib.dir}\portico.jar"/>
 			<env key="PORTICO_JNICHECK" value="true"/>

--- a/codebase/profiles/windows/hla13.xml
+++ b/codebase/profiles/windows/hla13.xml
@@ -124,8 +124,8 @@
 		         outdir="${test13.complete.dir}"
 		         type="executable"
 			     arch="x86"
-		         compilerArgs="${msvc.release.defaults}"
-		         linkerArgs="">
+		         compilerArgs="${compiler.args.debug}"
+		         linkerArgs="/DEBUG">
 			<fileset dir="${hla13.test.src.dir}" includes="**/*.cpp"/>
 			<includepath path="${hla13.include.dir}"/>
 			<includepath path="${hla13.src.dir}/hla/time"/>
@@ -133,7 +133,7 @@
 			<define name="RTI_USES_STD_FSTREAM"/>
 			<define name="DEBUG"/>
 			<library path="${hla13.complete.dir}/vc10" libs="RTI-NGd,FedTimed"/>
-			<library path="${cppunit.dir}/win32/vc10" libs="cppunit"/>
+			<library path="${cppunit.dir}/win32/vc10" libs="cppunitd"/>
 		</cpptask>
 	</target>
 

--- a/codebase/src/cpp/hla13/test/common/ActiveSR.cpp
+++ b/codebase/src/cpp/hla13/test/common/ActiveSR.cpp
@@ -18,16 +18,15 @@
 //////////////////////////////////////// Constructors ////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////
 ActiveSR::ActiveSR()
+	: label()
 {
-	this->label = NULL;
 	this->status = UNINITIATED;
 	this->federateHandle = -1;
 }
 
 ActiveSR::~ActiveSR()
 {
-	if( this->label != NULL )
-		delete [] this->label;
+
 }
 
 //////////////////////////////////////////////////////////////////////////////////////////////
@@ -35,10 +34,7 @@ ActiveSR::~ActiveSR()
 //////////////////////////////////////////////////////////////////////////////////////////////
 void ActiveSR::reset()
 {
-	if( this->label != NULL )
-		delete [] this->label;
-
-	this->label = NULL;
+	this->label = "";
 	this->status = UNINITIATED;
 }
 
@@ -72,13 +68,13 @@ void ActiveSR::failure()
 
 RTI::Boolean ActiveSR::isInitiated( const char* expectedLabel )
 {
-	if( this->label == NULL )
+	if( this->label.empty() )
 		return RTI::RTI_FALSE;
 	
 	if( this->status != INITIATED )
 		return RTI::RTI_FALSE;
 	
-	if( strcmp(this->label,expectedLabel) != 0 )
+	if( this->label != expectedLabel )
 		return RTI::RTI_FALSE;
 	else
 		return RTI::RTI_TRUE;
@@ -118,13 +114,7 @@ RTI::Boolean ActiveSR::isComplete()
 
 void ActiveSR::setLabel( const char* newLabel )
 {
-	char *buffer = new char[strlen(newLabel)];
-	strcpy( buffer, newLabel );
-	
-	if( this->label != NULL )
-		delete [] this->label;
-	
-	this->label = buffer;
+	this->label = string( newLabel );
 }
 
 int ActiveSR::getFederateHandle()

--- a/codebase/src/cpp/hla13/test/common/ActiveSR.h
+++ b/codebase/src/cpp/hla13/test/common/ActiveSR.h
@@ -32,7 +32,7 @@ class ActiveSR
 	//                   INSTANCE VARIABLES
 	//----------------------------------------------------------
 	private:
-		char *label;
+		std::string label;
 		SRStatus status;
 		int federateHandle; // used on restore requests
 

--- a/codebase/src/cpp/hla13/test/common/Test13FederateAmbassador.cpp
+++ b/codebase/src/cpp/hla13/test/common/Test13FederateAmbassador.cpp
@@ -1350,9 +1350,13 @@ Test13FederateAmbassador::fetchInteraction( RTI::InteractionClassHandle theClass
 	{
 		if( theClass == (*it)->getClassHandle() )
 		{
-			// remove the interaction and return it
+			// Need to get a reference to the found instance here before it is erased, otherwise
+			// it will point to something totally different
+			Test13Interaction* foundInteraction = (*it);
+
+			// remove the interaction
 			theStore->erase( it );
-			return (*it);
+			return foundInteraction;
 		}
 	}
 	

--- a/codebase/src/cpp/hla13/test/ddm/RequestUpdateWithRegionTest.cpp
+++ b/codebase/src/cpp/hla13/test/ddm/RequestUpdateWithRegionTest.cpp
@@ -125,9 +125,9 @@ void RequestUpdateWithRegionTest::testRequestUpdateWithRegion()
 
 	set<RTI::AttributeHandle>* secondAttributes =
 		defaultFederate->fedamb->waitForProvideRequest( secondObject );
-	CPPUNIT_ASSERT( secondAttributes->find(aaHandle) != firstAttributes->end() );
-	CPPUNIT_ASSERT( secondAttributes->find(abHandle) != firstAttributes->end() );
-	CPPUNIT_ASSERT( secondAttributes->find(acHandle) != firstAttributes->end() );
+	CPPUNIT_ASSERT( secondAttributes->find(aaHandle) != secondAttributes->end() );
+	CPPUNIT_ASSERT( secondAttributes->find(abHandle) != secondAttributes->end() );
+	CPPUNIT_ASSERT( secondAttributes->find(acHandle) != secondAttributes->end() );
 	delete secondAttributes;
 }
 


### PR DESCRIPTION
This PR has been raised in response to issue https://github.com/openlvc/portico/issues/124#issuecomment-74625037

The following work has been completed

### Build System Changes ###
- Found that the exec task that runs the hla13 test suite was setting the `PATH` env variable to `${hla13.complete.dir}`, however the actual compiled lib exists at `${hla13.complete.dir}\vc10`
- Added vc10 subdir to the `PATH` variable and the suite now executes
- `DEBUG` linker flag is now set when the test suite is compiled
- Test suite now links against a debug version of cppunit under Windows

### Test Code Changes ###
- Heap corruption was happening in the test utility class `ActiveSR` due when the char* label memory was deleted at some stage. I've converted it into a std::string so all memory management issue magically disappear! (spiritfingers)
- Fixed an iterator bug in `Test13FederateAmbassador::fetchInteraction()`
  * `vector->erase()` modifies the iterator state, so returning the dereferenced value of it in the next statement actually returns the next item in the vector
  * if the next item is the vector end, then the Microsoft version of STL throws a CRT exception saying the iterator can't be dereferenced
- Fixed a bug in `RequestUpdateWithRegionTest::testRequestUpdateWithRegion()` where `end()` was being called on a deleted map 
