### PR TITLE
PORT-126 Resign message now forwarded to LRC when a federate crash is confirmed

### DIFF
--- a/codebase/src/java/portico/org/portico/bindings/jgroups/channel/FederationListener.java
+++ b/codebase/src/java/portico/org/portico/bindings/jgroups/channel/FederationListener.java
@@ -133,6 +133,9 @@ public class FederationListener implements RequestHandler, MessageListener, Memb
 			                                     channel.jchannel.getAddress(),
 			                                     MessageHelpers.deflate(resign) );
 			
+			// dispatch resign message for the crashed federate to the LRC 
+			this.receive( resignMessage );
+			
 			logger.info( "Federate ["+federateName+","+federateHandle+
 			             "] disconnected, synthesizing resign message" );
 		}


### PR DESCRIPTION
This PR has been raised in response to issue https://github.com/openlvc/portico/issues/126#issuecomment-74778102

- Confirmed that `FederateListener.acceptView(View)` is called when the underlying JGroups mechanism confirms (not suspects) that a node has crashed
- Previously `FederateListener.acceptView(View)` was synthesising a `ResignFederation` message for each crashed federate, but never dispatching them to the LRC for processing.
- The resign messages are now forwarded on internally with a call to `FederateListener.receive()`

I've tested this under MacOS. The remaining federate takes a short time to announce it suspects the crash via the log, and then another short while to confirm it. After that execution resumes as normal.

Example output from the remaining federate is here:

```
INFO  [main] portico.lrc: PENDING Requested time advance for [fed1] to [12.0], waiting for grant...
WARN  [VERIFY_SUSPECT.TimerThread,ExampleFederation,localhost-4631] portico.lrc.jgroups: Detected that federate [1] may have crashed, investigating...
INFO  [Regular] portico.lrc.jgroups: Federate [fed2,2] disconnected, synthesizing resign message
ExampleFederate   : Time Advanced to 12.0
INFO  [main] portico.lrc: SUCCESS Updated object [2], attributes [509, 510, 511] (RO)
INFO  [main] portico.lrc: SUCCESS Updated object [2], attributes [509, 510, 511] @13.0
INFO  [main] portico.lrc: SUCCESS Sent interaction [518] with parameters [519, 520] (RO)
INFO  [main] portico.lrc: SUCCESS Sent interaction [518] with parameters [519, 520] @13.0
INFO  [main] portico.lrc: PENDING Requested time advance for [fed1] to [13.0], waiting for grant...
INFO  [main] portico.lrc: DELETED object [2097153]
FederateAmbassador: Object Removed: handle=2097153
```

The output shows 
1. The federate requesting a time advance to 12,
2. JGroups suspecting and confirming the crash 
3. The resign message for the crashed federate being synthesised and dispatched to the LRC
4. The federate being granted the time advance to 12 and continuing execution