### PR TITLE
PORT-132 Uninstaller entries now deleted on uninstall

### DIFF
--- a/codebase/resources/installers/windows/nsis/installer-win32.nsi
+++ b/codebase/resources/installers/windows/nsis/installer-win32.nsi
@@ -115,6 +115,9 @@ Section "Uninstall"
 
   RMDir /r "$INSTDIR"
 
+  ; Delete the registry keys related to uninstall
+  DeleteRegKey ${UNINST_ROOT_KEY} "${UNINST_KEY}"
+  
   ;delete the start menu items - current user
   SetShellVarContext current
   RMDir /r "$SMPROGRAMS\Portico-${VERSION}"

--- a/codebase/resources/installers/windows/nsis/installer-win64.nsi
+++ b/codebase/resources/installers/windows/nsis/installer-win64.nsi
@@ -119,6 +119,9 @@ Section "Uninstall"
 
   RMDir /r "$INSTDIR"
 
+  ; Delete the registry keys related to uninstall
+  DeleteRegKey ${UNINST_ROOT_KEY} "${UNINST_KEY}"
+  
   ;delete the start menu items - current user
   SetShellVarContext current
   RMDir /r "$SMPROGRAMS\Portico-${VERSION}"
@@ -126,5 +129,5 @@ Section "Uninstall"
   ;delete the start menu items - all users
   SetShellVarContext all
   RMDir /r "$SMPROGRAMS\Portico-${VERSION}"
-
+  
 SectionEnd


### PR DESCRIPTION
Forgot to include the bit where the uninstaller registry keys are removed on uninstall :)