### PR TITLE
PORT-212 Fixes typo that left HLAinteger64BE undefined in the FOM

### DIFF
--- a/codebase/src/java/portico/org/portico/lrc/model/datatype/DatatypeHelpers.java
+++ b/codebase/src/java/portico/org/portico/lrc/model/datatype/DatatypeHelpers.java
@@ -53,7 +53,7 @@ public class DatatypeHelpers
 	public static void injectStandardDatatypes( ObjectModel model )
 	{
 		BasicType hlaInt32Be = new BasicType( "HLAinteger32BE", 32, Endianness.BIG );
-		BasicType hlaInt64Be = new BasicType( "HLAinteger32BE", 64, Endianness.BIG );
+		BasicType hlaInt64Be = new BasicType( "HLAinteger64BE", 64, Endianness.BIG );
 		BasicType hlaFloat64Be = new BasicType( "HLAfloat64BE", 64, Endianness.BIG );
 		BasicType hlaOctetPairBe = new BasicType( "HLAoctetPairBE", 16, Endianness.BIG );
 		BasicType hlaOctet = new BasicType( "HLAoctet", 8, Endianness.BIG );


### PR DESCRIPTION
- Copy/paste error lead to HLAinteger32BE being declared twice in the code that automatically injects standard MIM datatypes into the FOM
- Fixed typo so that HLAinteger64BE is now defined with the proper traits