### PR TITLE
PORT-256 Defer linking until all FOM modules have been parsed and merged

### DIFF
--- a/codebase/src/cpp/ieee1516e/example/win32-vc14.bat
+++ b/codebase/src/cpp/ieee1516e/example/win32-vc14.bat
@@ -1,0 +1,59 @@
+@echo off
+
+rem ##########################################################################
+rem Please consult the README file to learn more about this example federate #
+rem ##########################################################################
+
+rem ################################
+rem # check command line arguments #
+rem ################################
+:checkargs
+if "%1" == "" goto usage
+
+rem ###################
+rem # Set up RTI_HOME #
+rem ###################
+:rtihome
+cd ..\..\..
+set RTI_HOME=%CD%
+cd examples\cpp\ieee1516e
+echo RTI_HOME environment variable is set to %RTI_HOME%
+goto run
+
+:run
+if "%1" == "clean" goto clean
+if "%1" == "compile" goto compile
+if "%1" == "execute" goto execute
+
+rem ############################################
+rem ### (target) clean #########################
+rem ############################################
+:clean
+echo Deleting example federate executable and left over logs
+del *.obj
+del main.exe
+rd /S /Q logs
+goto finish
+
+############################################
+### (target) compile #######################
+############################################
+:compile
+echo Compiling example federate
+cl /I"%RTI_HOME%\include\ieee1516e" /DRTI_USES_STD_FSTREAM /EHsc main.cpp ExampleCPPFederate.cpp ExampleFedAmb.cpp "%RTI_HOME%\lib\vc14\librti1516e.lib" "%RTI_HOME%\lib\vc14\libfedtime1516e.lib"
+goto finish
+
+############################################
+### (target) execute #######################
+############################################
+:execute
+SHIFT
+set PATH=%RTI_HOME%\jre\bin\client;%RTI_HOME%\bin\vc14;%PATH%
+main %1 %2 %3 %4 %5 %6 %7 %8 %9
+goto finish
+
+
+:usage
+echo usage: win32-vc14.bat [compile] [clean] [execute [federate-name]]
+
+:finish

--- a/codebase/src/cpp/ieee1516e/example/win64-vc14.bat
+++ b/codebase/src/cpp/ieee1516e/example/win64-vc14.bat
@@ -1,0 +1,59 @@
+@echo off
+
+rem ##########################################################################
+rem Please consult the README file to learn more about this example federate #
+rem ##########################################################################
+
+rem ################################
+rem # check command line arguments #
+rem ################################
+:checkargs
+if "%1" == "" goto usage
+
+rem ###################
+rem # Set up RTI_HOME #
+rem ###################
+:rtihome
+cd ..\..\..
+set RTI_HOME=%CD%
+cd examples\cpp\ieee1516e
+echo RTI_HOME environment variable is set to %RTI_HOME%
+goto run
+
+:run
+if "%1" == "clean" goto clean
+if "%1" == "compile" goto compile
+if "%1" == "execute" goto execute
+
+rem ############################################
+rem ### (target) clean #########################
+rem ############################################
+:clean
+echo Deleting example federate executable and left over logs
+del *.obj
+del main.exe
+rd /S /Q logs
+goto finish
+
+############################################
+### (target) compile #######################
+############################################
+:compile
+echo Compiling example federate
+cl /I"%RTI_HOME%\include\ieee1516e" /DRTI_USES_STD_FSTREAM /EHsc main.cpp ExampleCPPFederate.cpp ExampleFedAmb.cpp "%RTI_HOME%\lib\vc14\librti1516e64.lib" "%RTI_HOME%\lib\vc14\libfedtime1516e64.lib"
+goto finish
+
+############################################
+### (target) execute #######################
+############################################
+:execute
+SHIFT
+set PATH=%RTI_HOME%\jre\bin\server;%RTI_HOME%\bin\vc14;%PATH%
+main %1 %2 %3 %4 %5 %6 %7 %8 %9
+goto finish
+
+
+:usage
+echo usage: win64-vc14.bat [compile] [clean] [execute [federate-name]]
+
+:finish

--- a/codebase/src/cpp/ieee1516e/src/jni/Runtime.cpp
+++ b/codebase/src/cpp/ieee1516e/src/jni/Runtime.cpp
@@ -300,8 +300,8 @@ pair<string,string> Runtime::generatePaths() throw( RTIinternalError )
  * (Library Path)
  *   * System path
  *   * $RTI_HOME\bin
- *   * $JAVA_HOME\jre\lib\i386\client  (32-bit JRE)
- *   * $JAVA_HOME\jre\lib\amd64\server (64-bit JRE)
+ *   * $JAVA_HOME\jre\bin\client  (32-bit JRE)
+ *   * $JAVA_HOME\jre\bin\server (64-bit JRE)
  * 
  * If JAVA_HOME isn't set on the computer, RTI_HOME is used to link in with any JRE
  * that Portico has shipped with.  
@@ -351,6 +351,12 @@ pair<string,string> Runtime::generateWinPath( string rtihome ) throw( RTIinterna
 	libraryPath << "-Djava.library.path=.;"
 	            << string(systemPath) << ";"
 	            << rtihome << "\\bin\\"
+#ifdef VC14
+				<< "vc14"
+#endif
+#ifdef VC12
+				<< "vc12"
+#endif
 #ifdef VC11
 	            << "vc11"
 #endif
@@ -365,9 +371,9 @@ pair<string,string> Runtime::generateWinPath( string rtihome ) throw( RTIinterna
 #endif
 
 #ifdef _WIN32
-	            << jrelocation << "\\lib\\i386\\client";
+	            << jrelocation << "\\bin\\client";
 #else
-	            << jrelocation << "\\lib\\amd64\\server";
+	            << jrelocation << "\\bin\\server";
 #endif	
 
 	paths.second = libraryPath.str();

--- a/codebase/src/java/portico/org/portico/impl/hla1516e/fomparser/FOM.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516e/fomparser/FOM.java
@@ -32,8 +32,7 @@ import org.portico.lrc.model.Order;
 import org.portico.lrc.model.PCMetadata;
 import org.portico.lrc.model.Transport;
 import org.portico.lrc.model.datatype.IDatatype;
-import org.portico.lrc.model.datatype.linker.Linker;
-import org.portico.lrc.model.datatype.linker.LinkerException;
+import org.portico.lrc.model.datatype.linker.DatatypePlaceholder;
 import org.portico.utils.fom.FedHelpers;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -68,6 +67,12 @@ public class FOM
 	 * The main FOM parser processing method. This takes the root element of a FOM document and
 	 * parses it into an {@link ObjectModel} that is returned. If the parser is malformatted in
 	 * any way, a {@link JConfigurationException} is thrown.
+	 * <p/>
+	 * <b>Note:</b> Datatypes, Attributes and Parameters in the returned FOM will contain 
+	 * placeholder symbols as the datatypes that they refer to may be declared in another FOM 
+	 * module. Once all modules have been merged into a combined FOM, call 
+	 * {@link ObjectModel#resolveSymbols(ObjectModel)} to resolve all placeholder datatypes to their
+	 * concrete representation
 	 */
 	public ObjectModel process( Element element ) throws JErrorReadingFED
 	{
@@ -148,25 +153,15 @@ public class FOM
 			throw new JErrorReadingFED( jce );
 		}
 		
-		// Link and add types
-		Linker linker = new Linker();
-		linker.addCandidates( fom.getDatatypes() );
-		linker.addCandidates( fedTypes );
-		
+		// Add types
 		for( IDatatype fedType : fedTypes )
 		{
-			try
-			{
-				linker.linkType( fedType );
-			}
-			catch( LinkerException le )
-			{
-				throw new JErrorReadingFED( "Could not resolve dependency of " + 
-				                            fedType.getDatatypeClass() + " " + 
-				                            fedType.getName(),
-				                            le );
-			}
-			
+			// We used to link datatypes here on the assumption that FOM modules were 
+			// self-contained. However it appears that is not the reality, and that modules can
+			// reference datatypes that are only declared in other modules.
+			//
+			// As such we datatypes regardless of whether they contain placeholder symbols, and
+			// resolve them once all modules have been merged
 			fom.addDatatype( fedType );
 		}
 	}
@@ -251,15 +246,11 @@ public class FOM
 		for( Element attributeElement : attributes )
 		{
 			String attributeName = FedHelpers.getChildValue( attributeElement, "name" );
+			
+			// All attribute datatypes are initially created as placeholders, and resolved once
+			// all FOM modules have been merged and the standard MIM has been inserted
 			String datatypeName = FedHelpers.getChildValue( attributeElement, "dataType" );
-			IDatatype datatype = theModel.getDatatype( datatypeName );
-			if( datatype == null )
-			{
-				String message = String.format( "attribute %s references unknown datatype %s",
-				                                attributeName,
-				                                datatypeName );
-				throw new JConfigurationException( message );
-			}
+			IDatatype datatype = new DatatypePlaceholder( datatypeName );
 			
 			ACMetadata attribute = fom.newAttribute( attributeName, datatype );
 
@@ -392,15 +383,11 @@ public class FOM
 		for( Element parameterElement : parameters )
 		{
 			String parameterName = FedHelpers.getChildValue( parameterElement, "name" );
+			
+			// All parameter datatypes are initially created as placeholders, and resolved once
+			// all FOM modules have been merged and the standard MIM has been inserted
 			String datatypeName = FedHelpers.getChildValue( parameterElement, "dataType" );
-			IDatatype datatype = theModel.getDatatype( datatypeName );
-			if( datatype == null )
-			{
-				String message = String.format( "parameter %s references unknown datatype %s",
-				                                parameterName,
-				                                datatypeName );
-				throw new JConfigurationException( message );
-			}
+			IDatatype datatype = new DatatypePlaceholder( datatypeName );
 			
 			PCMetadata parameter = fom.newParameter( parameterName, datatype );
 			clazz.addParameter( parameter );

--- a/codebase/src/java/portico/org/portico/lrc/model/ACMetadata.java
+++ b/codebase/src/java/portico/org/portico/lrc/model/ACMetadata.java
@@ -81,6 +81,11 @@ public class ACMetadata implements Serializable
 		return this.datatype;
 	}
 	
+	public void setDatatype( IDatatype datatype )
+	{
+		this.datatype = datatype;
+	}
+	
 	public int getHandle()
 	{
 		return this.handle;

--- a/codebase/src/java/portico/org/portico/lrc/model/PCMetadata.java
+++ b/codebase/src/java/portico/org/portico/lrc/model/PCMetadata.java
@@ -65,6 +65,11 @@ public class PCMetadata implements Serializable
 		return this.datatype;
 	}
 	
+	public void setDatatype( IDatatype datatype )
+	{
+		this.datatype = datatype;
+	}
+	
 	public int getHandle()
 	{
 		return this.handle;

--- a/codebase/src/java/portico/org/portico/lrc/model/datatype/Dimension.java
+++ b/codebase/src/java/portico/org/portico/lrc/model/datatype/Dimension.java
@@ -144,8 +144,13 @@ public class Dimension implements Serializable
 				// Dynamic cardinality token
 				dimensions.add( Dimension.DYNAMIC );
 			}
-			else if( tokenTrimmed.startsWith( "(" ) && tokenTrimmed.endsWith(")") )
+			else if( (tokenTrimmed.startsWith( "(" ) && tokenTrimmed.endsWith(")")) ||
+			         (tokenTrimmed.startsWith( "[" ) && tokenTrimmed.endsWith("]")) )
 			{
+				// Note for above: From my understanding the standard only says that parentheses
+				// can be used for a cardinality range. The RPRv2 FOM uses square brackets however
+				// so I've added that as an exception
+				
 				// Cardinality range
 				String rangeString = tokenTrimmed.substring( 1, tokenTrimmed.length() - 1 );
 				String[] rangeTokens = rangeString.split( "\\.\\." );

--- a/codebase/src/java/portico/org/portico/lrc/model/datatype/linker/DatatypePlaceholder.java
+++ b/codebase/src/java/portico/org/portico/lrc/model/datatype/linker/DatatypePlaceholder.java
@@ -14,6 +14,8 @@
  */
 package org.portico.lrc.model.datatype.linker;
 
+import java.io.Serializable;
+
 import org.portico.lrc.model.datatype.DatatypeClass;
 import org.portico.lrc.model.datatype.IDatatype;
 
@@ -29,12 +31,13 @@ import org.portico.lrc.model.datatype.IDatatype;
  * 
  * @see Linker
  */
-public class DatatypePlaceholder implements IDatatype
+public class DatatypePlaceholder implements IDatatype, Serializable
 {
 	//----------------------------------------------------------
 	//                    STATIC VARIABLES
 	//----------------------------------------------------------
-
+	private static final long serialVersionUID = 3112252018924L;
+	
 	//----------------------------------------------------------
 	//                   INSTANCE VARIABLES
 	//----------------------------------------------------------

--- a/codebase/src/java/portico/org/portico/lrc/model/datatype/linker/EnumeratorPlaceholder.java
+++ b/codebase/src/java/portico/org/portico/lrc/model/datatype/linker/EnumeratorPlaceholder.java
@@ -14,6 +14,8 @@
  */
 package org.portico.lrc.model.datatype.linker;
 
+import java.io.Serializable;
+
 import org.portico.lrc.model.datatype.Alternative;
 import org.portico.lrc.model.datatype.EnumeratedType;
 import org.portico.lrc.model.datatype.IEnumerator;
@@ -24,11 +26,12 @@ import org.portico.lrc.model.datatype.IEnumerator;
  * such we are unable to tell if the Alternative's enumerator field contains a valid enumerator 
  * value. 
  */
-public class EnumeratorPlaceholder implements IEnumerator
+public class EnumeratorPlaceholder implements IEnumerator, Serializable
 {
 	//----------------------------------------------------------
 	//                    STATIC VARIABLES
 	//----------------------------------------------------------
+	private static final long serialVersionUID = 3112252018924L;
 
 	//----------------------------------------------------------
 	//                   INSTANCE VARIABLES

--- a/codebase/src/java/portico/org/portico/lrc/model/datatype/linker/Linker.java
+++ b/codebase/src/java/portico/org/portico/lrc/model/datatype/linker/Linker.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Set;
 
 import org.portico.lrc.compat.JConfigurationException;
+import org.portico.lrc.model.ACMetadata;
+import org.portico.lrc.model.PCMetadata;
 import org.portico.lrc.model.datatype.Alternative;
 import org.portico.lrc.model.datatype.ArrayType;
 import org.portico.lrc.model.datatype.BasicType;
@@ -179,7 +181,7 @@ public class Linker
 	 * then no action is performed on the type.
 	 * 
 	 * @param type The type to link
-	 * @throws LinkerException if the <code>code</code> contains {@link DatatypePlaceholder} references
+	 * @throws LinkerException if the <code>type</code> contains {@link DatatypePlaceholder} references
 	 *                         that can not be resolved
 	 */
 	public void linkType( IDatatype type ) throws LinkerException
@@ -286,6 +288,44 @@ public class Linker
 			{
 				// No action required
 				break;
+			}
+		}
+	}
+	
+	public void linkAttribute( ACMetadata attribute ) throws LinkerException
+	{
+		IDatatype datatype = attribute.getDatatype(); 
+		if( datatype instanceof DatatypePlaceholder )
+		{
+			try
+			{
+				IDatatype resolved = resolve( datatype );
+				attribute.setDatatype( resolved );
+			}
+			catch( LinkerException le )
+			{
+				// Rethrow the exception, but prefix the message with the attribute name
+				throw new LinkerException( "Attribute " + attribute.getName() + " " + le.getMessage(), 
+				                           le );
+			}
+		}
+	}
+	
+	public void linkParameter( PCMetadata parameter ) throws LinkerException
+	{
+		IDatatype datatype = parameter.getDatatype();
+		if( datatype instanceof DatatypePlaceholder )
+		{
+			try
+			{
+				IDatatype resolved = resolve( datatype );
+				parameter.setDatatype( resolved );
+			}
+			catch( LinkerException le )
+			{
+				// Rethrow the exception, but prefix the message with the parameter name
+				throw new LinkerException( "Parameter " + parameter.getName() + " " + le.getMessage(), 
+				                           le );
 			}
 		}
 	}

--- a/codebase/src/java/portico/org/portico/lrc/services/federation/handlers/outgoing/CreateFederationHandler.java
+++ b/codebase/src/java/portico/org/portico/lrc/services/federation/handlers/outgoing/CreateFederationHandler.java
@@ -77,6 +77,9 @@ public class CreateFederationHandler extends LRCMessageHandler
 		// look up MOM handles without using names (thus support cross spec-version naming schemes).
 		ObjectModel.mommify( combinedFOM );
 
+		// Now that all datatypes have been finalized, we can link the placeholder symbols
+		ObjectModel.resolveSymbols( combinedFOM );
+		
 		// we have our grand unified FOM!
 		request.setModel( combinedFOM );
 		
@@ -110,7 +113,7 @@ public class CreateFederationHandler extends LRCMessageHandler
 	//		foms.add( 0, FomParser.parse(mim) );
 	//	}
 	//}
-
+	
 	//----------------------------------------------------------
 	//                     STATIC METHODS
 	//----------------------------------------------------------


### PR DESCRIPTION
This PR has been submitted for bug ticket #256 

- When we initially developed the datatype parsing system, we worked under the assumption that all FOM modules were standalone in their own right - e.g. the datatypes has declarations for all datatypes that are referenced in the module.
- However in the modular RPRv2 FOM this is not the case. Datatypes, attributes and parameters can all reference datatypes that are declared soley in other FOM modules.
- As such a DatatypePlaceholder is now placed for all datatype links at parse time. Linking is deferred until all FOM modules have been parsed and merged, and the standard MIM has been inserted.
- Updated parsing unit tests to perform the delayed linking process.

*Note:* Branch has been merged off the PORT-254 branch.