### PR TITLE
PORT-254 New Java8 jvm.dll location added to PATH

### DIFF
--- a/codebase/src/cpp/ieee1516e/example/win32-vc14.bat
+++ b/codebase/src/cpp/ieee1516e/example/win32-vc14.bat
@@ -40,7 +40,7 @@ goto finish
 ############################################
 :compile
 echo Compiling example federate
-cl /I"%RTI_HOME%\include\ieee1516e" /DRTI_USES_STD_FSTREAM /EHsc main.cpp ExampleCPPFederate.cpp ExampleFedAmb.cpp "%RTI_HOME%\lib\vc10\librti1516e.lib" "%RTI_HOME%\lib\vc10\libfedtime1516e.lib"
+cl /I"%RTI_HOME%\include\ieee1516e" /DRTI_USES_STD_FSTREAM /EHsc main.cpp ExampleCPPFederate.cpp ExampleFedAmb.cpp "%RTI_HOME%\lib\vc14\librti1516e.lib" "%RTI_HOME%\lib\vc14\libfedtime1516e.lib"
 goto finish
 
 ############################################
@@ -48,12 +48,12 @@ goto finish
 ############################################
 :execute
 SHIFT
-set PATH=%RTI_HOME%\jre\bin\client;%RTI_HOME%\jre\lib\i386\client;%RTI_HOME%\bin\vc10;%PATH%
+set PATH=%RTI_HOME%\jre\bin\client;%RTI_HOME%\jre\lib\i386\client;%RTI_HOME%\bin\vc14;%PATH%
 main %1 %2 %3 %4 %5 %6 %7 %8 %9
 goto finish
 
 
 :usage
-echo usage: win32-vc10.bat [compile] [clean] [execute [federate-name]]
+echo usage: win32-vc14.bat [compile] [clean] [execute [federate-name]]
 
 :finish

--- a/codebase/src/cpp/ieee1516e/example/win64-vc10.bat
+++ b/codebase/src/cpp/ieee1516e/example/win64-vc10.bat
@@ -48,7 +48,7 @@ goto finish
 ############################################
 :execute
 SHIFT
-set PATH=%RTI_HOME%\jre\bin\server;%RTI_HOME%\bin\vc10;%PATH%
+set PATH=%RTI_HOME%\jre\bin\server;%RTI_HOME%\jre\lib\amd64\server;%RTI_HOME%\bin\vc10;%PATH%
 main %1 %2 %3 %4 %5 %6 %7 %8 %9
 goto finish
 

--- a/codebase/src/cpp/ieee1516e/example/win64-vc14.bat
+++ b/codebase/src/cpp/ieee1516e/example/win64-vc14.bat
@@ -40,7 +40,7 @@ goto finish
 ############################################
 :compile
 echo Compiling example federate
-cl /I"%RTI_HOME%\include\ieee1516e" /DRTI_USES_STD_FSTREAM /EHsc main.cpp ExampleCPPFederate.cpp ExampleFedAmb.cpp "%RTI_HOME%\lib\vc10\librti1516e.lib" "%RTI_HOME%\lib\vc10\libfedtime1516e.lib"
+cl /I"%RTI_HOME%\include\ieee1516e" /DRTI_USES_STD_FSTREAM /EHsc main.cpp ExampleCPPFederate.cpp ExampleFedAmb.cpp "%RTI_HOME%\lib\vc14\librti1516e64.lib" "%RTI_HOME%\lib\vc14\libfedtime1516e64.lib"
 goto finish
 
 ############################################
@@ -48,12 +48,12 @@ goto finish
 ############################################
 :execute
 SHIFT
-set PATH=%RTI_HOME%\jre\bin\client;%RTI_HOME%\jre\lib\i386\client;%RTI_HOME%\bin\vc10;%PATH%
+set PATH=%RTI_HOME%\jre\bin\server;%RTI_HOME%\jre\lib\amd64\server;%RTI_HOME%\bin\vc14;%PATH%
 main %1 %2 %3 %4 %5 %6 %7 %8 %9
 goto finish
 
 
 :usage
-echo usage: win32-vc10.bat [compile] [clean] [execute [federate-name]]
+echo usage: win64-vc14.bat [compile] [clean] [execute [federate-name]]
 
 :finish

--- a/codebase/src/cpp/ieee1516e/src/jni/Runtime.cpp
+++ b/codebase/src/cpp/ieee1516e/src/jni/Runtime.cpp
@@ -300,8 +300,10 @@ pair<string,string> Runtime::generatePaths() throw( RTIinternalError )
  * (Library Path)
  *   * System path
  *   * $RTI_HOME\bin
- *   * $JAVA_HOME\jre\lib\i386\client  (32-bit JRE)
- *   * $JAVA_HOME\jre\lib\amd64\server (64-bit JRE)
+ *   * $JAVA_HOME\jre\bin\client  (32-bit JRE)
+ *   * $JAVA_HOME\jre\bin\server (64-bit JRE)
+ *   * $JAVA_HOME\jre\lib\i386\client  (Pre-Java8 32-bit JRE)
+ *   * $JAVA_HOME\jre\lib\amd64\server (Pre Java8 64-bit JRE)
  * 
  * If JAVA_HOME isn't set on the computer, RTI_HOME is used to link in with any JRE
  * that Portico has shipped with.  
@@ -351,6 +353,12 @@ pair<string,string> Runtime::generateWinPath( string rtihome ) throw( RTIinterna
 	libraryPath << "-Djava.library.path=.;"
 	            << string(systemPath) << ";"
 	            << rtihome << "\\bin\\"
+#ifdef VC14
+				<< "vc14"
+#endif
+#ifdef VC12
+				<< "vc12"
+#endif
 #ifdef VC11
 	            << "vc11"
 #endif
@@ -365,8 +373,10 @@ pair<string,string> Runtime::generateWinPath( string rtihome ) throw( RTIinterna
 #endif
 
 #ifdef _WIN32
+	            << jrelocation << "\\bin\\client;"
 	            << jrelocation << "\\lib\\i386\\client";
 #else
+	            << jrelocation << "\\bin\\server;";
 	            << jrelocation << "\\lib\\amd64\\server";
 #endif	
 
@@ -463,7 +473,11 @@ string Runtime::getMode() throw( RTIinternalError )
  */
 string Runtime::getCompiler() throw( RTIinternalError )
 {
-#ifdef VC11
+#ifdef VC14
+	return string("-Dportico.cpp.compiler=vc14");
+#elif defined VC12
+	return string("-Dportico.cpp.compiler=vc12");
+#elif defined VC11
 	return string( "-Dportico.cpp.compiler=vc11" );
 #elif defined(VC10)
 	return string( "-Dportico.cpp.compiler=vc10" );


### PR DESCRIPTION
This is PR resolves portico issue #254, and is a resubmit of https://github.com/openlvc/portico/pull/255

- As we have updated the JRE over time it appears that the location of jvm.dll has changed. Previously `Runtime.cpp` set the path to `jre\lib\i386\client` (32-bit) or `jre\lib\amd64\server`.
- In the current version of java we use (8b144) jvm.dll is now located
in `jre\bin\client` (32-bit) or `jre\bin\server` (64-bit)
- Updated Runtime.cpp to append the correct locations to the PATH variable
- Updated vc10 cpp example batch file to append the correct locations to the PATH variable
- Added vc14 example batch files as a bonus!