### PR TITLE
PORT-258 privilegeToDelete renamed to privilegeToDeleteObject

### DIFF
--- a/codebase/src/java/portico/org/portico/lrc/model/OCMetadata.java
+++ b/codebase/src/java/portico/org/portico/lrc/model/OCMetadata.java
@@ -362,7 +362,7 @@ public class OCMetadata implements Serializable
 			// there is nothing higher to check, ensure that we're not talking about privToDelete,
 			// if we haven't found it yet it might because we've got the wrong HLA version
 			if( name != null &&
-				(name.equals("privilegeToDelete") || name.equals("HLAprivilegeToDelete")) )
+				(name.equals("privilegeToDelete") || name.equals("HLAprivilegeToDeleteObject")) )
 			{
 				return this.model.getPrivilegeToDelete();
 			}

--- a/codebase/src/java/portico/org/portico/lrc/model/ObjectModel.java
+++ b/codebase/src/java/portico/org/portico/lrc/model/ObjectModel.java
@@ -310,7 +310,7 @@ public class ObjectModel implements Serializable
 		{
 			// make sure we aren't talking privilegeToDelete
 			if( attributeName.equals("privilegeToDelete") ||
-				attributeName.equals("HLAprivilegeToDelete") )
+				attributeName.equals("HLAprivilegeToDeleteObject") )
 			{
 				return this.ocroot.getDeclaredAttribute( this.privilegeToDelete );
 			}

--- a/codebase/src/java/test/hlaunit/hla13/support/HandleFetchingTest.java
+++ b/codebase/src/java/test/hlaunit/hla13/support/HandleFetchingTest.java
@@ -160,7 +160,7 @@ public class HandleFetchingTest extends Abstract13Test
 			int orB13 = defaultFederate.rtiamb.getObjectClassHandle( "ObjectRoot.A.B" );
 			// check for priv to delete
 			int p13   = defaultFederate.rtiamb.getAttributeHandle( "privilegeToDelete", orB13 );
-			int p1516 = defaultFederate.rtiamb.getAttributeHandle( "HLAprivilegeToDelete", orB13 );
+			int p1516 = defaultFederate.rtiamb.getAttributeHandle( "HLAprivilegeToDeleteObject", orB13 );
 			Assert.assertEquals( p13, p1516, "privToDelete handles differ from 1.3 to 1516" );
 			
 			// check the 1516 handles and ensure they are the same as 1.3

--- a/codebase/src/java/test/hlaunit/ieee1516/support/PrivilegeToDeleteTest.java
+++ b/codebase/src/java/test/hlaunit/ieee1516/support/PrivilegeToDeleteTest.java
@@ -83,7 +83,7 @@ public class PrivilegeToDeleteTest extends Abstract1516Test
 		try
 		{
 			ObjectClassHandle oRoot = defaultFederate.rtiamb.getObjectClassHandle( "ObjectRoot" );
-			defaultFederate.rtiamb.getAttributeHandle( oRoot, "HLAprivilegeToDelete" );
+			defaultFederate.rtiamb.getAttributeHandle( oRoot, "HLAprivilegeToDeleteObject" );
 		}
 		catch( Exception e )
 		{

--- a/codebase/src/java/test/hlaunit/ieee1516e/federation/CreateFederationTest.java
+++ b/codebase/src/java/test/hlaunit/ieee1516e/federation/CreateFederationTest.java
@@ -578,10 +578,10 @@ public class CreateFederationTest extends Abstract1516eTest
 	{
 		defaultFederate.quickCreateWithModules( "resources/test-data/fom/ieee1516e/rpr/RPR-FOM2D18.xml" );
 		defaultFederate.quickJoin();
-		int handle = defaultFederate.quickACHandle( "HLAobjectRoot", "HLAprivilegeToDelete" );
+		int handle = defaultFederate.quickACHandle( "HLAobjectRoot", "HLAprivilegeToDeleteObject" );
 		
 		// make sure that we have a valid handle for privilegeToDelete
-		Assert.assertNotSame( handle, -1, "HLAprivilegeToDelete is not present in HLAobjectRoot" );
+		Assert.assertNotSame( handle, -1, "HLAprivilegeToDeleteObject is not present in HLAobjectRoot" );
 	}
 
 	

--- a/codebase/src/java/test/hlaunit/ieee1516e/support/PrivilegeToDeleteTest.java
+++ b/codebase/src/java/test/hlaunit/ieee1516e/support/PrivilegeToDeleteTest.java
@@ -83,7 +83,7 @@ public class PrivilegeToDeleteTest extends Abstract1516eTest
 		try
 		{
 			ObjectClassHandle oRoot = defaultFederate.rtiamb.getObjectClassHandle( "ObjectRoot" );
-			defaultFederate.rtiamb.getAttributeHandle( oRoot, "HLAprivilegeToDelete" );
+			defaultFederate.rtiamb.getAttributeHandle( oRoot, "HLAprivilegeToDeleteObject" );
 		}
 		catch( Exception e )
 		{


### PR DESCRIPTION
PR Submitted for issue PORT-258

- Renamed incorrectly name `privilegeToDelete` to IEEE1516e compliant `privilegeToDeleteObject`
- Updated all unit tests