### PR TITLE
Adds support for MOM Request/Report Object Model Data interactions

### DIFF
--- a/codebase/src/java/portico/org/portico/bindings/jgroups/JGroupsConnection.java
+++ b/codebase/src/java/portico/org/portico/bindings/jgroups/JGroupsConnection.java
@@ -243,9 +243,9 @@ public class JGroupsConnection implements IConnection
 		Federation federation = findFederation( joinMessage.getFederationName() );
 		
 		// validate that our FOM modules can be merged successfully with the existing FOM first
-		logger.debug( "Validate that ["+joinMessage.getJoinModules().size()+
+		logger.debug( "Validate that ["+joinMessage.getParsedJoinModules().size()+
 		              "] modules can merge successfully with the existing FOM" );
-		ModelMerger.mergeDryRun( federation.getManifest().getFom() , joinMessage.getJoinModules() );
+		ModelMerger.mergeDryRun( federation.getManifest().getFom() , joinMessage.getParsedJoinModules() );
 		logger.debug( "Modules can be merged successfully, continue with join" );
 
 		// tell the channel that we're joining the federation
@@ -268,14 +268,14 @@ public class JGroupsConnection implements IConnection
 		// specifics of this connection it's better to put the logic in the connection rather than
 		// in the generic-to-all-connections RoleCallHandler. Long way of saying we need to merge
 		// in the additional join modules that were provided here. F*** IT! WE'LL DO IT LIVE!
-		if( joinMessage.getJoinModules().size() > 0 )
+		if( joinMessage.getParsedJoinModules().size() > 0 )
 		{
-			logger.debug( "Merging "+joinMessage.getJoinModules().size()+
+			logger.debug( "Merging "+joinMessage.getParsedJoinModules().size()+
 			              " additional FOM modules that we receive with join request" );
 
 			ObjectModel fom = federation.getManifest().getFom();
 			fom.unlock();
-			federation.getManifest().setFom( ModelMerger.merge(fom,joinMessage.getJoinModules()) );
+			federation.getManifest().setFom( ModelMerger.merge(fom,joinMessage.getParsedJoinModules()) );
 			fom.lock();
 		}
 

--- a/codebase/src/java/portico/org/portico/bindings/jvm/JVMConnection.java
+++ b/codebase/src/java/portico/org/portico/bindings/jvm/JVMConnection.java
@@ -181,8 +181,8 @@ public class JVMConnection implements IConnection
 		
 		// Merge the provided join modules with the existing FOM - this method will
 		// perform a dry-run first to ensure that things can be merged happily
-		logger.debug( "Merge ["+joinMessage.getJoinModules().size()+"] modules into existing FOM" );
-		broadcaster.extendFOM( joinMessage.getJoinModules() );
+		logger.debug( "Merge ["+joinMessage.getParsedJoinModules().size()+"] modules into existing FOM" );
+		broadcaster.extendFOM( joinMessage.getParsedJoinModules() );
 
 		// join the federation
 		// this will check to see if there is already a federate with the same name

--- a/codebase/src/java/portico/org/portico/impl/hla1516e/types/HLA1516eHandle.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516e/types/HLA1516eHandle.java
@@ -14,6 +14,7 @@
  */
 package org.portico.impl.hla1516e.types;
 
+import org.portico.lrc.model.ObjectModel;
 import org.portico.utils.bithelpers.BitHelpers;
 
 import hla.rti1516e.AttributeHandle;
@@ -141,12 +142,16 @@ public class HLA1516eHandle implements AttributeHandle,
 	 */
 	public static <T> T decode( Class<T> standardType, byte[] buffer, int offset )
 	{
-		return standardType.cast( new HLA1516eHandle(BitHelpers.readIntBE(buffer,offset)) );
+		HLA1516eHandle handle = new HLA1516eHandle( ObjectModel.INVALID_HANDLE );
+		handle.decode( buffer, offset );
+		return standardType.cast( handle );
 	}
 
 	public static int decode( byte[] buffer )
 	{
-		return new HLA1516eHandle( BitHelpers.readIntBE(buffer,0) ).handle;
+		HLA1516eHandle handle = new HLA1516eHandle( ObjectModel.INVALID_HANDLE );
+		handle.decode( buffer, 0 );
+		return handle.handle;
 	}
 
 	///////////////////////////////////////////////////////////////////////////////////////////

--- a/codebase/src/java/portico/org/portico/lrc/model/Mom.java
+++ b/codebase/src/java/portico/org/portico/lrc/model/Mom.java
@@ -410,7 +410,7 @@ public class Mom
 							.parameter( "HLAsyncPointName", "HLAunicodeString" )	// This param is listed in the spec but not in the MIM xml :(
 						.end()
 						.interaction( "HLArequestFOMmoduleData" )
-							.parameter( "HLAfOMmoduleIndicator", "HLAindex" )
+							.parameter( "HLAFOMmoduleIndicator", "HLAindex" )
 						.end()
 						.interaction( "HLArequestMIMdata" ).end()
 					.end()

--- a/codebase/src/java/portico/org/portico/lrc/model/XmlRenderer.java
+++ b/codebase/src/java/portico/org/portico/lrc/model/XmlRenderer.java
@@ -1,0 +1,471 @@
+/*
+ *   Copyright 2006 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico.lrc.model;
+
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Result;
+import javax.xml.transform.Source;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpression;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
+import org.portico.lrc.model.datatype.Alternative;
+import org.portico.lrc.model.datatype.ArrayType;
+import org.portico.lrc.model.datatype.BasicType;
+import org.portico.lrc.model.datatype.DatatypeHelpers;
+import org.portico.lrc.model.datatype.EnumeratedType;
+import org.portico.lrc.model.datatype.Enumerator;
+import org.portico.lrc.model.datatype.Field;
+import org.portico.lrc.model.datatype.FixedRecordType;
+import org.portico.lrc.model.datatype.IDatatype;
+import org.portico.lrc.model.datatype.IEnumerator;
+import org.portico.lrc.model.datatype.SimpleType;
+import org.portico.lrc.model.datatype.VariantRecordType;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+
+/**
+ * This class will take an {@link ObjectModel} and render it as an XML document.
+ * <p/>
+ * Kindly donated by EMostafaAli!
+ */
+public class XmlRenderer
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	/**
+	 * Takes the given {@link ObjectModel} and converts it into an XML Document.
+	 */
+	public Document renderFOM( ObjectModel model )
+	{
+		try
+		{
+			DocumentBuilderFactory dbFactory = DocumentBuilderFactory.newInstance();
+			DocumentBuilder dbBuilder = dbFactory.newDocumentBuilder();
+			Document doc = dbBuilder.newDocument();
+			Element mainRootElement =
+			    doc.createElementNS( "http://standards.ieee.org/IEEE1516-2010", "objectModel" );
+			doc.appendChild( mainRootElement );
+			mainRootElement.appendChild( doc.createElement( "modelIdentification" ) );
+			Node objectsNode = mainRootElement.appendChild( doc.createElement("objects") );
+			renderObject( model.getObjectRoot(), doc, objectsNode );
+
+			Node intNode = mainRootElement.appendChild( doc.createElement("interactions") );
+			renderInteraction( model.getInteractionRoot(), doc, intNode );
+
+			Node dataNode = mainRootElement.appendChild( doc.createElement("dataTypes") );
+			renderDataType( model.getDatatypes(), doc, dataNode );
+
+			Node switchesNode = mainRootElement.appendChild( doc.createElement("switches") );
+			renderSwitches( doc, switchesNode );
+
+			mainRootElement.appendChild( doc.createElement("dimensions") );
+			mainRootElement.appendChild( doc.createElement("synchronizations") );
+			mainRootElement.appendChild( doc.createElement("transportations") );
+			mainRootElement.appendChild( doc.createElement("updateRates") );
+			mainRootElement.appendChild( doc.createElement("notes") );
+
+			return doc;
+		}
+		catch( ParserConfigurationException pce )
+		{
+			throw new IllegalStateException( pce );
+		}
+	}
+	
+	private void renderObject( OCMetadata oclass, Document doc, Node parentNode )
+	{
+		Node node = parentNode.appendChild( doc.createElement( "objectClass" ) );
+		addXMLAttribute( "name", oclass.getLocalName(), doc, node );
+		addXMLAttribute( "sharing", "PublishSubscribe", doc, node ); // TODO: use value from ObjectModel when available
+		addXMLAttribute( "semantics", "NA", doc, node ); // TODO: use value from ObjectModel when available
+		for( ACMetadata attribute : oclass.getDeclaredAttributes() )
+		{
+			Node attNode = node.appendChild( doc.createElement( "attribute" ) );
+			addXMLAttribute( "name", attribute.getName(), doc, attNode );
+			Node dataTypeNode = attNode.appendChild( doc.createElement( "dataType" ) );
+			dataTypeNode.appendChild( doc.createTextNode( attribute.getDatatype().getName() ) );
+			String orderType = "TimeStamp";
+			if( attribute.isRO() )
+				orderType = "Receive";
+
+			addXMLAttribute( "order", orderType, doc, attNode );
+			String transportationType = "HLAreliable";
+			if( attribute.getTransport() == Transport.BEST_EFFORT )
+				transportationType = "HLAbestEffort";
+			
+			addXMLAttribute( "transportation", transportationType, doc, attNode );
+			addXMLAttribute( "updateType", "Conditional", doc, attNode ); // TODO: use value from ObjectModel when available
+			addXMLAttribute( "ownership", "DivestAcquire", doc, attNode ); // TODO: use value from ObjectModel when available
+			addXMLAttribute( "sharing", "Neither", doc, attNode ); // TODO: use value from ObjectModel when available
+		}
+
+		for( OCMetadata subclass : oclass.getChildTypes() )
+			renderObject( subclass, doc, node );
+	}
+
+	private void renderInteraction( ICMetadata iclass, Document doc, Node parentNode )
+	{
+		Node node = parentNode.appendChild( doc.createElement( "interactionClass" ) );
+		addXMLAttribute( "name", iclass.getLocalName(), doc, node );
+		addXMLAttribute( "sharing", "PublishSubscribe", doc, node ); // TODO: use value from ObjectModel when available
+		String orderType = "TimeStamp";
+		if( iclass.isRO() )
+			orderType = "Receive";
+		
+		addXMLAttribute( "order", orderType, doc, node );
+		String transportationType = "HLAreliable";
+		if( iclass.getTransport() == Transport.BEST_EFFORT )
+			transportationType = "HLAbestEffort";
+		
+		addXMLAttribute( "transportation", transportationType, doc, node );
+
+		for( PCMetadata parameter : iclass.getDeclaredParameters() )
+		{
+			Node parNode = node.appendChild( doc.createElement( "Parameter" ) );
+			addXMLAttribute( "name", parameter.getName(), doc, parNode );
+			addXMLAttribute( "dataType", parameter.getDatatype().getName(), doc, parNode );
+		}
+
+		for( ICMetadata subinteraction : iclass.getChildTypes() )
+			renderInteraction( subinteraction, doc, node );
+	}
+
+	private void renderDataType( Set<IDatatype> dataTypes, Document doc, Node dataNode )
+	{
+		Node basicType = dataNode.appendChild( doc.createElement("basicDataRepresentations") );
+		Node simpleType = dataNode.appendChild( doc.createElement("simpleDataTypes") );
+		Node enumType = dataNode.appendChild( doc.createElement("enumeratedDataTypes") );
+		Node arrayType = dataNode.appendChild( doc.createElement("arrayDataTypes") );
+		Node fixedType = dataNode.appendChild( doc.createElement("fixedRecordDataTypes") );
+		Node variantType = dataNode.appendChild( doc.createElement("variantRecordDataTypes") );
+		for( IDatatype dataType : dataTypes )
+		{
+			switch( dataType.getDatatypeClass() )
+			{
+				case BASIC:
+				{
+					BasicType bType = (BasicType)dataType;
+					Node bNode = basicType.appendChild( doc.createElement("basicData") );
+					Node dataName = bNode.appendChild( doc.createElement("name") );
+					dataName.appendChild( doc.createTextNode( bType.getName() ) );
+					Node dataSize = bNode.appendChild( doc.createElement("size") );
+					dataSize.appendChild( doc.createTextNode(String.valueOf(bType.getSize())) );
+					Node dataEndian = bNode.appendChild( doc.createElement("endian") );
+					dataEndian.appendChild( doc.createTextNode(bType.getEndianness().name()) );
+					break;
+				}
+
+				case SIMPLE:
+				{
+					SimpleType sType = (SimpleType)dataType;
+					Node sNode = simpleType.appendChild( doc.createElement("simpleData") );
+					Node dataName = sNode.appendChild( doc.createElement("name") );
+					dataName.appendChild( doc.createTextNode(sType.getName()) );
+					Node dataSize = sNode.appendChild( doc.createElement("representation") );
+					dataSize.appendChild( doc.createTextNode(sType.getRepresentation().getName()) );
+					break;
+				}
+
+				case ENUMERATED:
+				{
+					EnumeratedType eType = (EnumeratedType)dataType;
+					Node sNode = enumType.appendChild( doc.createElement("enumeratedData") );
+					Node dataName = sNode.appendChild( doc.createElement("name") );
+					dataName.appendChild( doc.createTextNode(eType.getName()) );
+					Node dataSize = sNode.appendChild( doc.createElement("representation") );
+					dataSize.appendChild( doc.createTextNode(eType.getRepresentation().getName()) );
+					for( Enumerator e : eType.getEnumerators() )
+					{
+						Node enumNode = sNode.appendChild( doc.createElement("enumerator") );
+						Node enumName = enumNode.appendChild( doc.createElement("name") );
+						enumName.appendChild( doc.createTextNode(e.getName()) );
+						Node enumValue = enumNode.appendChild( doc.createElement("value") );
+						enumValue.appendChild( doc.createTextNode( e.getValue().toString() ) );
+					}
+					break;
+				}
+
+				case ARRAY:
+				{
+					ArrayType aType = (ArrayType)dataType;
+					Node sNode = arrayType.appendChild( doc.createElement("arrayData") );
+					Node dataName = sNode.appendChild( doc.createElement("name") );
+					dataName.appendChild( doc.createTextNode(aType.getName()) );
+					Node dataTypeNode = sNode.appendChild( doc.createElement( "dataType" ) );
+					dataTypeNode.appendChild( doc.createTextNode(aType.getDatatype().getName()) );
+					Node cardinality = sNode.appendChild( doc.createElement("cardinality") );
+					Node encoding = sNode.appendChild( doc.createElement("encoding") );
+					if( aType.isCardinalityDynamic() )
+					{
+						cardinality.appendChild( doc.createTextNode("Dynamic") );
+						encoding.appendChild( doc.createTextNode("HLAvariableArray") );
+					}
+					else
+					{
+						encoding.appendChild( doc.createTextNode("HLAfixedArray") );
+						List<String> upperBounds = new ArrayList<String>();
+						for( org.portico.lrc.model.datatype.Dimension d : aType.getDimensions() )
+							upperBounds.add( String.valueOf( d.getCardinalityUpperBound() ) );
+						
+						String boundsString = String.join( ",", upperBounds );
+						cardinality.appendChild( doc.createTextNode(boundsString) );
+					}
+					break;
+				}
+
+				case FIXEDRECORD:
+				{
+					FixedRecordType fType = (FixedRecordType)dataType;
+					Node sNode = fixedType.appendChild( doc.createElement("fixedRecordData") );
+					Node dataName = sNode.appendChild( doc.createElement("name") );
+					dataName.appendChild( doc.createTextNode( fType.getName() ) );
+					Node encoding = sNode.appendChild( doc.createElement("encoding") );
+					encoding.appendChild( doc.createTextNode("HLAfixedRecord") );
+					for( Field e : fType.getFields() )
+					{
+						Node fieldNode = sNode.appendChild( doc.createElement("field") );
+						Node fieldName = fieldNode.appendChild( doc.createElement("name") );
+						fieldName.appendChild( doc.createTextNode(e.getName()) );
+						Node enumValue = fieldNode.appendChild( doc.createElement("dataType") );
+						enumValue.appendChild( doc.createTextNode(e.getDatatype().getName()) );
+					}
+
+					break;
+				}
+
+				case VARIANTRECORD:
+				{
+					VariantRecordType vType = (VariantRecordType)dataType;
+					Node sNode =
+					    variantType.appendChild( doc.createElement("variantRecordData") );
+					Node dataName = sNode.appendChild( doc.createElement("name") );
+					dataName.appendChild( doc.createTextNode(vType.getName()) );
+					Node encoding = sNode.appendChild( doc.createElement("encoding") );
+					encoding.appendChild( doc.createTextNode("HLAvariantRecord") );
+					Node discNode = sNode.appendChild( doc.createElement("discriminant") );
+					discNode.appendChild( doc.createTextNode(vType.getDiscriminantName()) );
+					Node discTypeNode = sNode.appendChild( doc.createElement("dataType") );
+					String discName = vType.getDiscriminantDatatype().getName();
+					discTypeNode.appendChild( doc.createTextNode(discName) );
+					for( Alternative e : vType.getAlternatives() )
+					{
+						Node fieldNode = sNode.appendChild( doc.createElement("alternative") );
+						Node fieldName = fieldNode.appendChild( doc.createElement("name") );
+						fieldName.appendChild( doc.createTextNode(e.getName()) );
+						Node dataValue = fieldNode.appendChild( doc.createElement("dataType") );
+						dataValue.appendChild( doc.createTextNode(e.getDatatype().getName()) );
+						Node enumValue = fieldNode.appendChild( doc.createElement("enumerator") );
+						List<String> values = new ArrayList<String>();
+						for( IEnumerator v : e.getEnumerators() )
+							values.add( v.getName() );
+						
+						String valueString = String.join( ",", values );
+						enumValue.appendChild( doc.createTextNode(valueString) );
+					}
+
+					break;
+				}
+				default:
+					break;
+			}
+		}
+	}
+
+	private void renderSwitches( Document doc, Node switches )
+	{
+
+		Element autoProvide = doc.createElement( "autoProvide" );
+		autoProvide.setAttribute( "isEnabled", "true" );
+		switches.appendChild( autoProvide );
+		
+		Element conveyRegionDesignatorSets = doc.createElement( "conveyRegionDesignatorSets" );
+		conveyRegionDesignatorSets.setAttribute( "isEnabled", "false" );
+		switches.appendChild( conveyRegionDesignatorSets );
+		
+		Element conveyProducingFederate = doc.createElement( "conveyProducingFederate" );
+		conveyProducingFederate.setAttribute( "isEnabled", "false" );
+		switches.appendChild( conveyProducingFederate );
+		
+		Element attributeScopeAdvisory = doc.createElement( "attributeScopeAdvisory" );
+		attributeScopeAdvisory.setAttribute( "isEnabled", "false" );
+		switches.appendChild( attributeScopeAdvisory );
+		
+		Element attributeRelevanceAdvisory = doc.createElement( "attributeRelevanceAdvisory" );
+		attributeRelevanceAdvisory.setAttribute( "isEnabled", "false" );
+		switches.appendChild( attributeRelevanceAdvisory );
+		
+		Element objectClassRelevanceAdvisory = doc.createElement( "objectClassRelevanceAdvisory" );
+		objectClassRelevanceAdvisory.setAttribute( "isEnabled", "true" );
+		switches.appendChild( objectClassRelevanceAdvisory );
+		
+		Element interactionRelevanceAdvisory = doc.createElement( "interactionRelevanceAdvisory" );
+		interactionRelevanceAdvisory.setAttribute( "isEnabled", "true" );
+		switches.appendChild( interactionRelevanceAdvisory );
+		
+		Element serviceReporting = doc.createElement( "serviceReporting" );
+		serviceReporting.setAttribute( "isEnabled", "false" );
+		switches.appendChild( serviceReporting );
+		
+		Element exceptionReporting = doc.createElement( "exceptionReporting" );
+		exceptionReporting.setAttribute( "isEnabled", "false" );
+		switches.appendChild( exceptionReporting );
+		
+		Element delaySubscriptionEvaluation = doc.createElement( "delaySubscriptionEvaluation" );
+		delaySubscriptionEvaluation.setAttribute( "isEnabled", "false" );
+		switches.appendChild( delaySubscriptionEvaluation );
+		
+		Element automaticResignAction = doc.createElement( "automaticResignAction" );
+		automaticResignAction.setAttribute( "resignAction", "CancelThenDeleteThenDivest" );
+		switches.appendChild( automaticResignAction );
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	private static void addXMLAttribute( String attName,
+	                                     String value,
+	                                     Document doc,
+	                                     Node parentNode )
+	{
+		Node attNode = parentNode.appendChild( doc.createElement( attName ) );
+		attNode.appendChild( doc.createTextNode( value ) );
+	}
+	
+	public static String xmlToString( Document document )
+	{
+		try
+		{
+			// Remove white space
+			document.normalize();
+			XPathFactory xpathFactory = XPathFactory.newInstance();
+			
+			// XPath to find empty text nodes.
+			XPathExpression xpathExp = xpathFactory.newXPath().compile("//text()[normalize-space(.) = '']");  
+			NodeList emptyTextNodes = (NodeList) 
+			xpathExp.evaluate(document, XPathConstants.NODESET);
+
+			// Remove each empty text node from document.
+			for ( int i = 0; i < emptyTextNodes.getLength(); ++i ) 
+			{
+				Node emptyTextNode = emptyTextNodes.item(i);
+				emptyTextNode.getParentNode().removeChild(emptyTextNode);
+			}
+
+			Source source = new DOMSource( document );
+			StringWriter writer = new StringWriter();
+			Result result = new StreamResult( writer );
+
+			Transformer xformer = TransformerFactory.newInstance().newTransformer();
+			xformer.setOutputProperty( OutputKeys.INDENT, "yes" );
+			xformer.setOutputProperty( OutputKeys.METHOD, "xml" );
+			xformer.setOutputProperty( "{http://xml.apache.org/xslt}indent-amount", "4" );
+
+			xformer.transform( source, result );
+			return writer.toString();
+		}
+		catch( TransformerException te )
+		{
+			// Programmer error, should not be thrown
+			throw new IllegalStateException( te );
+		} 
+		catch( XPathExpressionException e ) 
+		{
+			// Programmer error, should not be thrown
+			throw new IllegalArgumentException( e );
+		}
+	}
+	
+	private static class DatatypeComparator implements Comparator<IDatatype>
+	{
+		@Override
+		public int compare( IDatatype o1, IDatatype o2 )
+		{
+			int result = o1.getDatatypeClass().compareTo( o2.getDatatypeClass() );
+			if( result == 0 )
+				result = o1.getName().compareTo( o2.getName() );
+			
+			return result;
+		}		
+	}
+	
+	private static class EnumeratorComparator implements Comparator<IEnumerator>
+	{
+		@Override
+		public int compare( IEnumerator o1, IEnumerator o2 )
+		{
+			long o1Value = o1.getValue().longValue();
+			long o2Value = o2.getValue().longValue();
+			
+			if( o1Value == o2Value )
+				return 0;
+			else if( o1Value > o2Value )
+				return 1;
+			else
+				return -1;
+		}
+		
+	}
+	
+	private static class AlternativeComparator implements Comparator<Alternative>
+	{
+		private EnumeratorComparator enumCompare;
+		
+		public AlternativeComparator()
+		{
+			this.enumCompare = new EnumeratorComparator();
+		}
+		
+		@Override
+		public int compare( Alternative o1, Alternative o2 )
+		{
+			IEnumerator o1Lowest = DatatypeHelpers.getLowestEnumerator( o1.getEnumerators() );
+			IEnumerator o2Lowest = DatatypeHelpers.getLowestEnumerator( o2.getEnumerators() );
+			
+			return enumCompare.compare( o1Lowest, o2Lowest );
+		}		
+	}
+}
+

--- a/codebase/src/java/portico/org/portico/lrc/services/federation/handlers/outgoing/CreateFederationHandler.java
+++ b/codebase/src/java/portico/org/portico/lrc/services/federation/handlers/outgoing/CreateFederationHandler.java
@@ -27,6 +27,7 @@ import org.portico.utils.fom.FomParser;
 import org.portico.utils.messaging.MessageContext;
 import org.portico.utils.messaging.MessageHandler;
 import org.portico2.common.services.federation.msg.CreateFederation;
+import org.portico2.rti.services.mom.data.FomModule;
 
 @MessageHandler(modules="lrc-base",
                 keywords={"lrc13","lrcjava1","lrc1516","lrc1516e"},
@@ -61,8 +62,12 @@ public class CreateFederationHandler extends LRCMessageHandler
 		
 		// try and parse each of the fed files that we have
 		List<ObjectModel> foms = new ArrayList<ObjectModel>();
-		for( URL module : request.getFomModules() )
+		List<FomModule> modules = new ArrayList<FomModule>();
+		for( URL module : request.getFomModuleLocations() )
+		{
 			foms.add( FomParser.parse(module) );
+			modules.add( new FomModule(module) );
+		}
 		
 		// -- NOT DONE ANY MORE --
 		// Used to be important, but we will manually insert the MOM with handles we can control
@@ -81,7 +86,7 @@ public class CreateFederationHandler extends LRCMessageHandler
 		ObjectModel.resolveSymbols( combinedFOM );
 		
 		// we have our grand unified FOM!
-		request.setModel( combinedFOM );
+		request.setModel( combinedFOM, modules );
 		
 		// check that we don't have a null name
 		if( request.getFederationName() == null )

--- a/codebase/src/java/portico/org/portico/lrc/services/federation/handlers/outgoing/JoinFederationHandler.java
+++ b/codebase/src/java/portico/org/portico/lrc/services/federation/handlers/outgoing/JoinFederationHandler.java
@@ -93,7 +93,7 @@ public class JoinFederationHandler extends LRCMessageHandler
 		if( request.getFomModuleLocations().size() > 0 )
 		{
 			for( URL fedLocation : request.getFomModuleLocations() )
-				request.addJoinModule( FomParser.parse(fedLocation) );
+				request.addJoinModule( fedLocation, FomParser.parse(fedLocation) );
 			
 			// let people know what happened
 			logger.debug( "Parsed ["+request.getParsedJoinModules().size()+"] additional FOM modules" );

--- a/codebase/src/java/portico/org/portico/lrc/services/federation/handlers/outgoing/JoinFederationHandler.java
+++ b/codebase/src/java/portico/org/portico/lrc/services/federation/handlers/outgoing/JoinFederationHandler.java
@@ -90,13 +90,13 @@ public class JoinFederationHandler extends LRCMessageHandler
 		logger.debug( "ATTEMPT Join federate ["+federate+"] to federation ["+federation+"]" );
 		
 		// parse any additional FOM modules and store back in the request for processing
-		if( request.getFomModules().size() > 0 )
+		if( request.getFomModuleLocations().size() > 0 )
 		{
-			for( URL fedLocation : request.getFomModules() )
+			for( URL fedLocation : request.getFomModuleLocations() )
 				request.addJoinModule( FomParser.parse(fedLocation) );
 			
 			// let people know what happened
-			logger.debug( "Parsed ["+request.getJoinModules().size()+"] additional FOM modules" );
+			logger.debug( "Parsed ["+request.getParsedJoinModules().size()+"] additional FOM modules" );
 		}
 		
 		///////////////////////////////
@@ -125,7 +125,7 @@ public class JoinFederationHandler extends LRCMessageHandler
 		// broadcast out the notification so that other federates know we're in the federation
 		rolecall.setSourceFederate( federateHandle );
 		rolecall.setImmediateProcessingFlag( true );
-		rolecall.addAdditionalFomModules( request.getJoinModules() );
+		rolecall.addAdditionalFomModules( request.getParsedJoinModules() );
 		connection.broadcast( rolecall );
 		
 		// wait until we have gotten a RoleCall from everyone, this ensures we don't end

--- a/codebase/src/java/portico/org/portico/lrc/services/mom/data/MomFederate.java
+++ b/codebase/src/java/portico/org/portico/lrc/services/mom/data/MomFederate.java
@@ -279,7 +279,7 @@ public class MomFederate
 			int attributeHandle = instance.getType().getHandle();
 			if( attributes.containsKey(attributeHandle) )
 			{
-				String canonicalName = Mom.getMomAttributeName( version, 
+				String canonicalName = Mom.getMomAttributeName( HLAVersion.HLA13, 
 				                                                attributeHandle );
 				Function<HLAVersion,byte[]> encoder = this.attributeEncoders.get( canonicalName );
 				if( encoder != null )

--- a/codebase/src/java/portico/org/portico/lrc/services/mom/data/MomFederation.java
+++ b/codebase/src/java/portico/org/portico/lrc/services/mom/data/MomFederation.java
@@ -192,7 +192,7 @@ public class MomFederation
 			int attributeHandle = instance.getType().getHandle();
 			if( handles.contains(attributeHandle) )
 			{
-				String canonicalName = Mom.getMomAttributeName( version,  
+				String canonicalName = Mom.getMomAttributeName( HLAVersion.HLA13,  
 				                                                attributeHandle );
 				Function<HLAVersion,byte[]> encoder = this.attributeEncoders.get( canonicalName );
 				if( encoder != null )

--- a/codebase/src/java/portico/org/portico2/common/services/federation/msg/CreateFederation.java
+++ b/codebase/src/java/portico/org/portico2/common/services/federation/msg/CreateFederation.java
@@ -16,12 +16,14 @@ package org.portico2.common.services.federation.msg;
 
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import org.portico.impl.HLAVersion;
 import org.portico.lrc.model.ObjectModel;
 import org.portico.utils.messaging.PorticoMessage;
 import org.portico2.common.messaging.MessageType;
+import org.portico2.rti.services.mom.data.FomModule;
 
 /**
  * Contains information relating to a request to create a new federation. The component creating
@@ -39,9 +41,10 @@ public class CreateFederation extends PorticoMessage
 	//                   INSTANCE VARIABLES
 	//----------------------------------------------------------
 	private String federationName;
-	private transient List<URL> fomModules;
+	private transient List<URL> fomModuleLocations;
 	private ObjectModel objectModel;
 	private HLAVersion hlaVersion;
+	private List<FomModule> rawFomModules;
 
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
@@ -49,7 +52,8 @@ public class CreateFederation extends PorticoMessage
 	public CreateFederation()
 	{
 		super();
-		this.fomModules = new ArrayList<URL>();
+		this.fomModuleLocations = new ArrayList<URL>();
+		this.rawFomModules = new ArrayList<FomModule>();
 	}
 	
 	public CreateFederation( String federationName, ObjectModel model )
@@ -63,7 +67,7 @@ public class CreateFederation extends PorticoMessage
 	{
 		this();
 		this.federationName = federationName;
-		this.fomModules.add( fedfileLocation );
+		this.fomModuleLocations.add( fedfileLocation );
 	}
 	
 	public CreateFederation( String federationName, URL[] fomModules )
@@ -71,14 +75,14 @@ public class CreateFederation extends PorticoMessage
 		this();
 		this.federationName = federationName;
 		for( URL module : fomModules )
-			this.fomModules.add( module );
+			this.fomModuleLocations.add( module );
 	}
 	
 	public CreateFederation( String federationName, List<URL> fomModules )
 	{
 		this();
 		this.federationName = federationName;
-		this.fomModules.addAll( fomModules );
+		this.fomModuleLocations.addAll( fomModules );
 	}
 
 	//----------------------------------------------------------
@@ -100,9 +104,11 @@ public class CreateFederation extends PorticoMessage
 		this.federationName = federationName;
 	}
 	
-	public void setModel( ObjectModel model )
+	public void setModel( ObjectModel model, Collection<FomModule> rawModules )
 	{
 		this.objectModel = model;
+		this.rawFomModules.clear();
+		this.rawFomModules.addAll( rawModules );
 	}
 	
 	public ObjectModel getModel()
@@ -110,9 +116,14 @@ public class CreateFederation extends PorticoMessage
 		return this.objectModel;
 	}
 	
-	public List<URL> getFomModules()
+	public List<URL> getFomModuleLocations()
 	{
-		return this.fomModules;
+		return this.fomModuleLocations;
+	}
+	
+	public List<FomModule> getRawFomModules()
+	{
+		return this.rawFomModules;
 	}
 	
 	public void setHlaVersion( HLAVersion version )
@@ -124,8 +135,7 @@ public class CreateFederation extends PorticoMessage
 	{
 		return this.hlaVersion;
 	}
-
-
+	
 	//----------------------------------------------------------
 	//                     STATIC METHODS
 	//----------------------------------------------------------

--- a/codebase/src/java/portico/org/portico2/common/services/federation/msg/JoinFederation.java
+++ b/codebase/src/java/portico/org/portico2/common/services/federation/msg/JoinFederation.java
@@ -22,6 +22,7 @@ import org.portico.lrc.model.ObjectModel;
 import org.portico.utils.messaging.PorticoMessage;
 import org.portico2.common.messaging.MessageType;
 import org.portico2.rti.RtiConnection;
+import org.portico2.rti.services.mom.data.FomModule;
 
 public class JoinFederation extends PorticoMessage
 {
@@ -35,9 +36,10 @@ public class JoinFederation extends PorticoMessage
 	//----------------------------------------------------------
 	private String federateName;
 	private String federationName;
-	private List<ObjectModel> joinModules; // parsed version of object FOM modules below
+	private List<ObjectModel> parsedJoinObjectModels; // parsed version of object FOM modules below
+	private List<FomModule> rawJoinObjectModels;      // raw version of FOM modules below
 
-	private transient List<URL> fomModules;
+	private transient List<URL> fomModuleLocations;
 	private transient ObjectModel fom;
 	private transient RtiConnection connection; // ewww, separation-of-concerns! RTI need this sadly
 	                                            // FIXME Put this in some kind of generic map or something
@@ -50,8 +52,9 @@ public class JoinFederation extends PorticoMessage
 	{
 		super();
 		this.setImmediateProcessingFlag( true );
-		this.joinModules = new ArrayList<ObjectModel>();
-		this.fomModules = new ArrayList<URL>();
+		this.rawJoinObjectModels = new ArrayList<FomModule>();
+		this.parsedJoinObjectModels = new ArrayList<ObjectModel>();
+		this.fomModuleLocations = new ArrayList<URL>();
 	}
 
 	public JoinFederation( String federationName, String federateName )
@@ -67,7 +70,7 @@ public class JoinFederation extends PorticoMessage
 		if( fomModules != null )
 		{
     		for( URL module : fomModules )
-    			this.fomModules.add( module );
+    			this.fomModuleLocations.add( module );
 		}
 	}
 
@@ -106,17 +109,24 @@ public class JoinFederation extends PorticoMessage
 		return true;
 	}
 
+	public List<FomModule> getRawJoinModules()
+	{
+		return this.rawJoinObjectModels;
+	}
+	
 	/**
 	 * Returns a list of all the FOM modules that this federate is trying to join with.
 	 */
-	public List<ObjectModel> getJoinModules()
+	public List<ObjectModel> getParsedJoinModules()
 	{
-		return this.joinModules;
+		return this.parsedJoinObjectModels;
 	}
 	
-	public void addJoinModule( ObjectModel module )
+	public void addJoinModule( URL from, ObjectModel module )
 	{
-		this.joinModules.add( module );
+		FomModule raw = new FomModule( from );
+		this.rawJoinObjectModels.add( raw );
+		this.parsedJoinObjectModels.add( module );
 	}
 	
 	//////////////////////////////////////////////////
@@ -132,9 +142,14 @@ public class JoinFederation extends PorticoMessage
 		this.fom = fom;
 	}
 	
-	public List<URL> getFomModules()
+	public List<URL> getFomModuleLocations()
 	{
-		return this.fomModules;
+		return this.fomModuleLocations;
+	}
+	
+	public List<FomModule> getRawFomModules()
+	{
+		return this.rawJoinObjectModels;
 	}
 
 	public RtiConnection getConnection()

--- a/codebase/src/java/portico/org/portico2/lrc/services/federation/outgoing/CreateFederationHandler.java
+++ b/codebase/src/java/portico/org/portico2/lrc/services/federation/outgoing/CreateFederationHandler.java
@@ -28,6 +28,7 @@ import org.portico.utils.fom.FomParser;
 import org.portico2.common.messaging.MessageContext;
 import org.portico2.common.services.federation.msg.CreateFederation;
 import org.portico2.lrc.LRCMessageHandler;
+import org.portico2.rti.services.mom.data.FomModule;
 
 public class CreateFederationHandler extends LRCMessageHandler
 {
@@ -63,8 +64,12 @@ public class CreateFederationHandler extends LRCMessageHandler
 		
 		// try and parse each of the fed files that we have
 		List<ObjectModel> foms = new ArrayList<ObjectModel>();
-		for( URL module : request.getFomModules() )
+		List<FomModule> modules = new ArrayList<FomModule>();
+		for( URL module : request.getFomModuleLocations() )
+		{
 			foms.add( FomParser.parse(module) );
+			modules.add( new FomModule(module) );
+		}
 		
 		// -- NOT DONE ANY MORE --
 		// Used to be important, but we will manually insert the MOM with handles we can control
@@ -80,7 +85,7 @@ public class CreateFederationHandler extends LRCMessageHandler
 		ObjectModel.mommify( combinedFOM );
 
 		// we have our grand unified FOM!
-		request.setModel( combinedFOM );
+		request.setModel( combinedFOM, modules );
 		
 		// log the request and pass it on to the connection
 		logger.debug( "ATTEMPT Create federation execution [" + request.getFederationName() + "]" );

--- a/codebase/src/java/portico/org/portico2/lrc/services/federation/outgoing/JoinFederationHandler.java
+++ b/codebase/src/java/portico/org/portico2/lrc/services/federation/outgoing/JoinFederationHandler.java
@@ -86,13 +86,13 @@ public class JoinFederationHandler extends LRCMessageHandler
 		logger.debug( "ATTEMPT Join federate ["+federate+"] to federation ["+federation+"]" );
 		
 		// parse any additional FOM modules and store back in the request for processing
-		if( request.getFomModules().size() > 0 )
+		if( request.getFomModuleLocations().size() > 0 )
 		{
-			for( URL fedLocation : request.getFomModules() )
-				request.addJoinModule( FomParser.parse(fedLocation) );
+			for( URL fedLocation : request.getFomModuleLocations() )
+				request.addJoinModule( fedLocation, FomParser.parse(fedLocation) );
 			
 			// let people know what happened
-			logger.debug( "Parsed ["+request.getJoinModules().size()+"] additional FOM modules" );
+			logger.debug( "Parsed ["+request.getParsedJoinModules().size()+"] additional FOM modules" );
 		}
 		
 		/////////////////////////////////

--- a/codebase/src/java/portico/org/portico2/rti/RtiInbox.java
+++ b/codebase/src/java/portico/org/portico2/rti/RtiInbox.java
@@ -190,6 +190,7 @@ public class RtiInbox
 		logger.info( "ATTEMPT Creating federation name="+name );
 		
 		Federation federation = federationManager.createFederation( rti, name, fom, hlaVersion );
+		federation.addRawFomModules( request.getRawFomModules() );
 		
 		logger.info( "SUCCESS Created federation name="+name );
 		context.success( federation.getFederationHandle() );

--- a/codebase/src/java/portico/org/portico2/rti/federation/Federate.java
+++ b/codebase/src/java/portico/org/portico2/rti/federation/Federate.java
@@ -14,9 +14,15 @@
  */
 package org.portico2.rti.federation;
 
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.portico2.common.PorticoConstants;
 import org.portico2.common.services.time.data.TimeStatus;
 import org.portico2.rti.RtiConnection;
+import org.portico2.rti.services.mom.data.FomModule;
 
 public class Federate
 {
@@ -31,6 +37,7 @@ public class Federate
 	private int federateHandle;
 	private RtiConnection federateConnection;
 	private FederateMetrics metrics;
+	private List<FomModule> fomModules;
 	
 	private TimeStatus timeStatus;
 
@@ -43,6 +50,7 @@ public class Federate
 		this.federateConnection = federateConnection;
 		this.metrics = new FederateMetrics();
 		this.federateHandle = PorticoConstants.NULL_HANDLE;
+		this.fomModules = new ArrayList<FomModule>();
 		
 		this.timeStatus = new TimeStatus();
 	}
@@ -84,6 +92,28 @@ public class Federate
 		return this.metrics;
 	}
 
+	public void addRawFomModules( List<FomModule> modules )
+	{
+		// As per the 1516e spec, only modules that add something to the FOM are to be recorded. To keep
+		// things simple, we'll just assume that if the designator is different then the module added
+		// new content
+		Set<String> existingDesignators = new HashSet<>();
+		for( FomModule existingModule : this.fomModules )
+			existingDesignators.add( existingModule.getDesignator() );
+		
+		for( FomModule newModule : modules )
+		{
+			String newDesignator = newModule.getDesignator();
+			if( !existingDesignators.contains(newDesignator) )
+				this.fomModules.add( newModule );
+		}
+	}
+	
+	public List<FomModule> getRawFomModules()
+	{
+		return new ArrayList<>( this.fomModules );
+	}
+	
 	//////////////////////////////////////////////////////////////////////////////////////
 	/// Message Sending and Processing  //////////////////////////////////////////////////
 	//////////////////////////////////////////////////////////////////////////////////////

--- a/codebase/src/java/portico/org/portico2/rti/services/federation/incoming/JoinFederationHandler.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/federation/incoming/JoinFederationHandler.java
@@ -66,6 +66,8 @@ public class JoinFederationHandler extends RTIMessageHandler
 
 		// Create the federate and attach it to the federation
 		Federate federate = new Federate( federateName, request.getConnection() );
+		federate.addRawFomModules( request.getRawFomModules() );
+		
 		int federateHandle = federation.joinFederate( federate );
 		
 		logger.info( "SUCCESS Federate [%s] joined federation [%s] with handle [%d]",

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/FomModule.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/FomModule.java
@@ -1,0 +1,91 @@
+/*
+ *   Copyright 2018 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.rti.services.mom.data;
+
+import java.io.File;
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.portico.lrc.compat.JCouldNotOpenFED;
+import org.portico.lrc.compat.JErrorReadingFED;
+
+/**
+ * Represents the raw, unparsed content of a FED file
+ */
+public class FomModule implements Serializable
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private URL url;
+	private String content;
+	private String designator;
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public FomModule()
+	{
+		this.content = null;
+		this.designator = null;
+	}
+
+	public FomModule( URL moduleUrl )
+		throws JCouldNotOpenFED, JErrorReadingFED
+	{
+		try
+		{
+			URI moduleUri = moduleUrl.toURI();
+			File moduleFile = new File( moduleUri );
+			this.designator = moduleFile.getName();
+			
+			Path modulePath = Paths.get( moduleUri );
+			this.content = new String( Files.readAllBytes(modulePath) );
+		}
+		catch( Exception e )
+		{
+			// Should not happen as the module was parsed into XML before this constructor was called
+			throw new JErrorReadingFED( moduleUrl.toString() );
+		}
+	}
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+	public String getDesignator()
+	{
+		return this.designator;
+	}
+	
+	public String getContent()
+	{
+		return this.content;
+	}
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomEncodingHelpers.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomEncodingHelpers.java
@@ -72,15 +72,19 @@ public class MomEncodingHelpers
 		this.encoders.put( "HLAcount", this::encodeInt32BE );
 		this.encoders.put( "HLAhandle", this::encodeHandle );
 		this.encoders.put( "HLAhandleList", this::encodeHandleList );
+		this.encoders.put( "HLAindex", this::encodeInt32BE );
 		this.encoders.put( "HLAlogicalTime", this::encodeTime );
 		this.encoders.put( "HLAmsec", this::encodeInt32BE );
 		this.encoders.put( "HLAsynchPointList", this::encodeUnicodeStringVariableArray );
 		this.encoders.put( "HLAtimeInterval", this::encodeTimeInterval );
 		this.encoders.put( "HLAunicodeString", this::encodeUnicodeString );
 		this.encoders.put( "HLAsynchPointFederateList", this::encodeSynchPointFederateList );
+		this.encoders.put( "HLAmoduleDesignatorList", this::encodeUnicodeStringVariableArray );
 		
 		this.decoders = new HashMap<>();
 		this.decoders.put( "HLAASCIIstring", this::decodeAsciiString );
+		this.decoders.put( "HLAhandle", this::decodeHandle );
+		this.decoders.put( "HLAindex", this::decodeInt32BE );
 		this.decoders.put( "HLAunicodeString", this::decodeUnicodeString );
 	}
 
@@ -270,6 +274,25 @@ public class MomEncodingHelpers
 		else
 		{
 			throw new JRTIinternalError( "non-SynchPointFederate array type: " + data.getClass() );
+		}
+	}
+	
+	public int decodeInt32BE( byte[] value ) throws DecoderException
+	{
+		HLAinteger32BE int32BE = this.factory.createHLAinteger32BE();
+		int32BE.decode( value );
+		return int32BE.getValue();
+	}
+	
+	public int decodeHandle( byte[] value ) throws DecoderException
+	{
+		try
+		{
+			return HLA1516eHandle.decode( value );
+		}
+		catch( Exception e )
+		{
+			throw new DecoderException( e.getMessage(), e );
 		}
 	}
 	

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomFederate.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomFederate.java
@@ -15,6 +15,7 @@
 package org.portico2.rti.services.mom.data;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -195,7 +196,14 @@ public class MomFederate
 	
 	private byte[] getFomModuleDesignatorList( ACMetadata metadata )
 	{
-		return notYetSupported( "HLAFOMmoduleDesignatorList" );
+		IDatatype type = metadata.getDatatype();
+		List<FomModule> modules = federate.getRawFomModules();
+		int moduleCount = modules.size();
+		String[] designators = new String[moduleCount];
+		for( int i = 0 ; i < moduleCount ; ++i )
+			designators[i] = modules.get( i ).getDesignator();
+		
+		return MomEncodingHelpers.encode( type, designators );
 	}
 
 	private byte[] getRTIversion( ACMetadata metadata )

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomFederation.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomFederation.java
@@ -16,6 +16,7 @@ package org.portico2.rti.services.mom.data;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
@@ -29,11 +30,13 @@ import org.portico.lrc.compat.JEncodingHelpers;
 import org.portico.lrc.model.ACMetadata;
 import org.portico.lrc.model.Mom;
 import org.portico.lrc.model.ObjectModel;
+import org.portico.lrc.model.XmlRenderer;
 import org.portico.lrc.model.datatype.IDatatype;
 import org.portico2.common.services.object.msg.UpdateAttributes;
 import org.portico2.rti.federation.Federation;
 import org.portico2.rti.services.object.data.RACInstance;
 import org.portico2.rti.services.object.data.ROCInstance;
+import org.w3c.dom.Document;
 
 /**
  * Contains links between the {@link OCInstance} used to represent the federation in the federation
@@ -210,12 +213,24 @@ public class MomFederation
 
 	private byte[] getFomModuleDesignatorList( ACMetadata metadata )
 	{
-		return notYetSupported( "HLAFOMmoduleDesignatorList" );
+		IDatatype type = metadata.getDatatype();
+		List<FomModule> modules = federation.getRawFomModules();
+		int moduleCount = modules.size();
+		String[] designators = new String[moduleCount];
+		for( int i = 0 ; i < moduleCount ; ++i )
+			designators[i] = modules.get( i ).getDesignator();
+		
+		return MomEncodingHelpers.encode( type, designators );
 	}
 
 	private byte[] getCurrentFdd( ACMetadata metadata )
 	{
-		return notYetSupported( "HLAcurrentFDD" );
+		IDatatype type = metadata.getDatatype();
+		ObjectModel fom = federation.getFOM();
+		Document asXml = new XmlRenderer().renderFOM( fom );
+		String asString = XmlRenderer.xmlToString( asXml );
+		
+		return MomEncodingHelpers.encode( type, asString );
 	}
 
 	private byte[] getTimeImplementationName( ACMetadata metadata )


### PR DESCRIPTION
Work completed for Portico ticket #236.

- Fixed decoding of `HLA1516eHandle` through the static decode methods
- Corrected spelling of `HLAfederation.HLArequest.HLArequestFOMmoduleData` parameter `HLAFOMmoduleIndicator`
- `CreateFederation` and `JoinFederation` objects now contain the unparsed content of each FOM module that they were called with
  * This data is included to support `HLArequestFOMmoduleDesignatorList` and `HLArequestFOMmoduleData` interactions
  * Data is saved against the `Federation` and `Federate` object models
  * Will likely need to be parsed within the `JoinFederation` handler so that the unified federation ObjectModel can be extended
- Added support for the `HLAmanager.HLAfederation` attributes `HLAFOMmoduleDesignatorList` and `HLAcurrentFDD`
- Added support for the `HLAmanager.HLAfederate` attribute `HLAFOMmoduleDesignatorList`
- Added support for `HLAmanager.HLAfederate.HLArequest.HLArequestFOMmoduleData` and its corresponding response `HLAmanager.HLAfederate.HLAreport.HLAreportFOMmoduleData`
- Added support for `HLAmanager.HLAfederation.HLArequest.HLArequestFOMmoduleData` and its
 corresponding response `HLAmanager.HLAfederation.HLAreport.HLAreportFOMmoduleData`
- Added support for `HLAmanager.HLAfederation.HLArequest.HLArequestMIMdata` and its corresponding response `HLAmanager.HLAfederation.HLAreport.HLAreportMIMdata`