### PR TITLE
Adds MOM interaction support for object and interaction metrics

### DIFF
--- a/codebase/src/java/portico/org/portico2/common/services/pubsub/data/InterestManager.java
+++ b/codebase/src/java/portico/org/portico2/common/services/pubsub/data/InterestManager.java
@@ -1251,6 +1251,80 @@ public class InterestManager implements SaveRestoreTarget
 		return set;
 	}
 	
+	/**
+	 * Returns a set of object class handles that the provided federate has a publication interest in.
+	 * 
+	 * @param federateHandle the handle of the federate to find all object class publications for
+	 * @return a set of object class handles that the provided federate has a publication interest in
+	 */
+	public Set<Integer> getAllPublishedObjectClasses( int federateHandle )
+	{
+		Set<Integer> objectClasses = new HashSet<>();
+		for( OCInterest interest : this.pObjects.values() )
+		{
+			if( interest.hasInterest(federateHandle) )
+				objectClasses.add( interest.getObjectClass().getHandle() );
+		}
+		
+		return objectClasses;
+	}
+	
+	/**
+	 * Returns a set of object class handles that the provided federate has a subscription interest in.
+	 * 
+	 * @param federateHandle the handle of the federate to find all object class subscriptions for
+	 * @return a set of object class handles that the provided federate has a subscription interest in
+	 */
+	public Set<Integer> getAllSubscribedObjectClasses( int federateHandle )
+	{
+		Set<Integer> objectClasses = new HashSet<>();
+		for( OCInterest interest : this.sObjects.values() )
+		{
+			if( interest.hasInterest(federateHandle) )
+				objectClasses.add( interest.getObjectClass().getHandle() );
+		}
+		
+		return objectClasses;
+	}
+	
+	/**
+	 * Returns a set of interaction class handles that the provided federate has a publication interest 
+	 * in.
+	 * 
+	 * @param federateHandle the handle of the federate to find all interaction class publications for
+	 * @return a set of interaction class handles that the provided federate has a publication interest in
+	 */
+	public Set<Integer> getAllPublishedInteractionClasses( int federateHandle )
+	{
+		Set<Integer> interactionClasses = new HashSet<>();
+		for( ICInterest interest : this.pInteractions.values() )
+		{
+			if( interest.hasInterest(federateHandle) )
+				interactionClasses.add( interest.getInteractionClass().getHandle() );
+		}
+		
+		return interactionClasses;
+	}
+	
+	/**
+	 * Returns a set of interaction class handles that the provided federate has a subscription interest 
+	 * in.
+	 * 
+	 * @param federateHandle the handle of the federate to find all interaction class subscriptions for
+	 * @return a set of interaction class handles that the provided federate has a subscriptions interest in
+	 */
+	public Set<Integer> getAllSubscribedInteractionClasses( int federateHandle )
+	{
+		Set<Integer> interactionClasses = new HashSet<>();
+		for( ICInterest interest : this.sInteractions.values() )
+		{
+			if( interest.hasInterest(federateHandle) )
+				interactionClasses.add( interest.getInteractionClass().getHandle() );
+		}
+		
+		return interactionClasses;
+	}
+	
 	//////////////////////////////////////////////////////////////////////////////////////////
 	///////////////////////////////// Private Helper Methods /////////////////////////////////
 	//////////////////////////////////////////////////////////////////////////////////////////

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/InteractionCount.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/InteractionCount.java
@@ -55,6 +55,7 @@ public class InteractionCount implements DataElement
 	{
 		return 4;
 	}
+	
 	@Override
 	public void encode( ByteWrapper byteWrapper ) throws EncoderException
 	{
@@ -62,11 +63,13 @@ public class InteractionCount implements DataElement
 		handle.encode( byteWrapper );
 		byteWrapper.putInt( count );
 	}
+	
 	@Override
 	public int getEncodedLength()
 	{
 		return HLA1516eHandle.EncodedLength + 4;
 	}
+	
 	@Override
 	public byte[] toByteArray() throws EncoderException
 	{
@@ -74,11 +77,13 @@ public class InteractionCount implements DataElement
 		this.encode( wrapper );
 		return wrapper.array();
 	}
+	
 	@Override
 	public void decode( ByteWrapper byteWrapper ) throws DecoderException
 	{
 		throw new UnsupportedOperationException();
 	}
+	
 	@Override
 	public void decode( byte[] bytes ) throws DecoderException
 	{

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/InteractionCount.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/InteractionCount.java
@@ -22,11 +22,11 @@ import hla.rti1516e.encoding.DecoderException;
 import hla.rti1516e.encoding.EncoderException;
 
 /**
- * An immutable record of the number of instances of a particular object class.
+ * A count of a particular interaction class.
  * <p/>
- * This class mirrors the HLAobjectClassBasedCount Fixed Record structure defined in the MOM 
+ * This class mirrors the HLAinteractionCount Fixed Record structure defined in the MOM 
  */
-public class ObjectClassBasedCount implements DataElement
+public class InteractionCount implements DataElement
 {
 	//----------------------------------------------------------
 	//                    STATIC VARIABLES
@@ -41,7 +41,7 @@ public class ObjectClassBasedCount implements DataElement
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
 	//----------------------------------------------------------
-	public ObjectClassBasedCount( int classHandle, int count )
+	public InteractionCount( int classHandle, int count )
 	{
 		this.classHandle = classHandle;
 		this.count = count;
@@ -96,6 +96,16 @@ public class ObjectClassBasedCount implements DataElement
 	public int getCount()
 	{
 		return this.count;
+	}
+	
+	public void increment()
+	{
+		++this.count;
+	}
+	
+	public void setCount( int count )
+	{
+		this.count = count;
 	}
 
 	//----------------------------------------------------------

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/InteractionSubscription.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/InteractionSubscription.java
@@ -1,0 +1,101 @@
+/*
+ *   Copyright 2018 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.rti.services.mom.data;
+
+import org.portico.impl.hla1516e.types.HLA1516eHandle;
+import org.portico.impl.hla1516e.types.encoding.HLA1516eBoolean;
+
+import hla.rti1516e.encoding.ByteWrapper;
+import hla.rti1516e.encoding.DataElement;
+import hla.rti1516e.encoding.DecoderException;
+import hla.rti1516e.encoding.EncoderException;
+
+/**
+ * Represents a federate's subscription to an interaction.
+ * <p/>
+ * This class mirrors the HLAinteractionSubscription Fixed Record structure defined in the MOM 
+ */
+public class InteractionSubscription implements DataElement
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private int interactionClass;
+	private boolean active;
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public InteractionSubscription( int interactionClass )
+	{
+		this( interactionClass, true );
+	}
+	
+	public InteractionSubscription( int interactionClass, boolean active )
+	{
+		this.interactionClass = interactionClass;
+		this.active = active;
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	public int getOctetBoundary()
+	{
+		return HLA1516eHandle.EncodedLength;
+	}
+	@Override
+	public void encode( ByteWrapper byteWrapper ) throws EncoderException
+	{
+		new HLA1516eHandle( this.interactionClass ).encode( byteWrapper );
+		new HLA1516eBoolean( this.active ).encode( byteWrapper );
+	}
+	@Override
+	public int getEncodedLength()
+	{
+		return HLA1516eHandle.EncodedLength + 4;
+	}
+	@Override
+	public byte[] toByteArray() throws EncoderException
+	{
+		ByteWrapper wrapper = new ByteWrapper( getEncodedLength() );
+		this.encode( wrapper );
+		return wrapper.array();
+	}
+	@Override
+	public void decode( ByteWrapper byteWrapper ) throws DecoderException
+	{
+		throw new UnsupportedOperationException();
+	}
+	@Override
+	public void decode( byte[] bytes ) throws DecoderException
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/InteractionSubscription.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/InteractionSubscription.java
@@ -61,17 +61,20 @@ public class InteractionSubscription implements DataElement
 	{
 		return HLA1516eHandle.EncodedLength;
 	}
+	
 	@Override
 	public void encode( ByteWrapper byteWrapper ) throws EncoderException
 	{
 		new HLA1516eHandle( this.interactionClass ).encode( byteWrapper );
 		new HLA1516eBoolean( this.active ).encode( byteWrapper );
 	}
+	
 	@Override
 	public int getEncodedLength()
 	{
 		return HLA1516eHandle.EncodedLength + 4;
 	}
+	
 	@Override
 	public byte[] toByteArray() throws EncoderException
 	{
@@ -79,11 +82,13 @@ public class InteractionSubscription implements DataElement
 		this.encode( wrapper );
 		return wrapper.array();
 	}
+	
 	@Override
 	public void decode( ByteWrapper byteWrapper ) throws DecoderException
 	{
 		throw new UnsupportedOperationException();
 	}
+	
 	@Override
 	public void decode( byte[] bytes ) throws DecoderException
 	{

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomEncodingHelpers.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomEncodingHelpers.java
@@ -73,12 +73,14 @@ public class MomEncodingHelpers
 		this.encoders.put( "HLAhandle", this::encodeHandle );
 		this.encoders.put( "HLAhandleList", this::encodeHandleList );
 		this.encoders.put( "HLAindex", this::encodeInt32BE );
+		this.encoders.put( "HLAinteractionCounts", this::encodeInteractionCounts );
 		this.encoders.put( "HLAlogicalTime", this::encodeTime );
 		this.encoders.put( "HLAmoduleDesignatorList", this::encodeUnicodeStringVariableArray );
 		this.encoders.put( "HLAmsec", this::encodeInt32BE );
 		this.encoders.put( "HLAobjectClassBasedCounts", this::encodeObjectClassBasedCounts );
 		this.encoders.put( "HLAsynchPointList", this::encodeUnicodeStringVariableArray );
 		this.encoders.put( "HLAtimeInterval", this::encodeTimeInterval );
+		this.encoders.put( "HLAtransportationName", this::encodeUnicodeString );
 		this.encoders.put( "HLAunicodeString", this::encodeUnicodeString );
 		this.encoders.put( "HLAsynchPointFederateList", this::encodeSynchPointFederateList );
 		
@@ -293,6 +295,24 @@ public class MomEncodingHelpers
 		else
 		{
 			throw new JRTIinternalError( "non-ObjectClassBasedCount array type: " + data.getClass() );
+		}
+	}
+	
+	public byte[] encodeInteractionCounts( Object data )
+	{
+		if( data == null )
+			data = new InteractionCount[0];
+		
+		if( data instanceof InteractionCount[] )
+		{
+			InteractionCount[] asArray = (InteractionCount[])data;
+			HLAvariableArray<InteractionCount> hlaArray = factory.createHLAvariableArray( null, 
+			                                                                              asArray );
+			return hlaArray.toByteArray();
+		}
+		else
+		{
+			throw new JRTIinternalError( "non-InteractionCount array type: " + data.getClass() );
 		}
 	}
 	

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomEncodingHelpers.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomEncodingHelpers.java
@@ -14,6 +14,7 @@
  */
 package org.portico2.rti.services.mom.data;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -74,6 +75,7 @@ public class MomEncodingHelpers
 		this.encoders.put( "HLAhandleList", this::encodeHandleList );
 		this.encoders.put( "HLAindex", this::encodeInt32BE );
 		this.encoders.put( "HLAinteractionCounts", this::encodeInteractionCounts );
+		this.encoders.put( "HLAinteractionSubList", this::encodeInteractionSubList );
 		this.encoders.put( "HLAlogicalTime", this::encodeTime );
 		this.encoders.put( "HLAmoduleDesignatorList", this::encodeUnicodeStringVariableArray );
 		this.encoders.put( "HLAmsec", this::encodeInt32BE );
@@ -82,6 +84,7 @@ public class MomEncodingHelpers
 		this.encoders.put( "HLAtimeInterval", this::encodeTimeInterval );
 		this.encoders.put( "HLAtransportationName", this::encodeUnicodeString );
 		this.encoders.put( "HLAunicodeString", this::encodeUnicodeString );
+		this.encoders.put( "HLAupdateRateName", this::encodeUnicodeString );
 		this.encoders.put( "HLAsynchPointFederateList", this::encodeSynchPointFederateList );
 		
 		this.decoders = new HashMap<>();
@@ -194,6 +197,17 @@ public class MomEncodingHelpers
 	
 	public byte[] encodeHandleList( Object data )
 	{
+		if( data instanceof Collection<?> )
+		{
+			@SuppressWarnings("unchecked")
+			Collection<Integer> asCollection = (Collection<Integer>)data;
+			int[] temp = new int[asCollection.size()];
+			int index = 0;
+			for( int element : asCollection )
+				temp[index++] = element;
+			data = temp;
+		}
+		
 		if( data instanceof int[] )
 		{
 			int[] asIntArray = (int[])data;
@@ -313,6 +327,24 @@ public class MomEncodingHelpers
 		else
 		{
 			throw new JRTIinternalError( "non-InteractionCount array type: " + data.getClass() );
+		}
+	}
+	
+	public byte[] encodeInteractionSubList( Object data )
+	{
+		if( data == null )
+			data = new InteractionSubscription[0];
+		
+		if( data instanceof InteractionSubscription[] )
+		{
+			InteractionSubscription[] asArray = (InteractionSubscription[])data;
+			HLAvariableArray<InteractionSubscription> hlaArray = factory.createHLAvariableArray( null, 
+			                                                                                     asArray );
+			return hlaArray.toByteArray();
+		}
+		else
+		{
+			throw new JRTIinternalError( "non-InteractionSubscription array type: " + data.getClass() );
 		}
 	}
 	

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomEncodingHelpers.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomEncodingHelpers.java
@@ -74,12 +74,13 @@ public class MomEncodingHelpers
 		this.encoders.put( "HLAhandleList", this::encodeHandleList );
 		this.encoders.put( "HLAindex", this::encodeInt32BE );
 		this.encoders.put( "HLAlogicalTime", this::encodeTime );
+		this.encoders.put( "HLAmoduleDesignatorList", this::encodeUnicodeStringVariableArray );
 		this.encoders.put( "HLAmsec", this::encodeInt32BE );
+		this.encoders.put( "HLAobjectClassBasedCounts", this::encodeObjectClassBasedCounts );
 		this.encoders.put( "HLAsynchPointList", this::encodeUnicodeStringVariableArray );
 		this.encoders.put( "HLAtimeInterval", this::encodeTimeInterval );
 		this.encoders.put( "HLAunicodeString", this::encodeUnicodeString );
 		this.encoders.put( "HLAsynchPointFederateList", this::encodeSynchPointFederateList );
-		this.encoders.put( "HLAmoduleDesignatorList", this::encodeUnicodeStringVariableArray );
 		
 		this.decoders = new HashMap<>();
 		this.decoders.put( "HLAASCIIstring", this::decodeAsciiString );
@@ -274,6 +275,24 @@ public class MomEncodingHelpers
 		else
 		{
 			throw new JRTIinternalError( "non-SynchPointFederate array type: " + data.getClass() );
+		}
+	}
+	
+	public byte[] encodeObjectClassBasedCounts( Object data )
+	{
+		if( data == null )
+			data = new ObjectClassBasedCount[0];
+		
+		if( data instanceof ObjectClassBasedCount[] )
+		{
+			ObjectClassBasedCount[] asArray = (ObjectClassBasedCount[])data;
+			HLAvariableArray<ObjectClassBasedCount> hlaArray = factory.createHLAvariableArray( null, 
+			                                                                                   asArray );
+			return hlaArray.toByteArray();
+		}
+		else
+		{
+			throw new JRTIinternalError( "non-ObjectClassBasedCount array type: " + data.getClass() );
 		}
 	}
 	

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomFederate.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomFederate.java
@@ -287,46 +287,74 @@ public class MomFederate
 	private byte[] getReflectionsReceived( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		return MomEncodingHelpers.encode( type, federate.getMetrics().getReflectionsReceived() );
+		ObjectClassBasedCount[] updated = federate.getMetrics().getReflectionsReceived();
+		int grandTotal = 0;
+		for( ObjectClassBasedCount classCount : updated )
+			grandTotal += classCount.getCount();
+		
+		return MomEncodingHelpers.encode( type, grandTotal );
 	}
 
 	private byte[] getUpdatesSent( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		return MomEncodingHelpers.encode( type, federate.getMetrics().getUpdatesSent() );
+		ObjectClassBasedCount[] updated = federate.getMetrics().getUpdatesSent();
+		int grandTotal = 0;
+		for( ObjectClassBasedCount classCount : updated )
+			grandTotal += classCount.getCount();
+		
+		return MomEncodingHelpers.encode( type, grandTotal );
 	}
 
 	private byte[] getInteractionsReceived( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		return MomEncodingHelpers.encode( type, federate.getMetrics().getInteractionsReceived() );
+		InteractionCount[] received = federate.getMetrics().getInteractionsReceived();
+		int grandTotal = 0;
+		for( InteractionCount classCount : received )
+			grandTotal += classCount.getCount();
+		
+		return MomEncodingHelpers.encode( type, grandTotal );
 	}
 
 	private byte[] getInteractionsSent( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		return MomEncodingHelpers.encode( type, federate.getMetrics().getInteractionsSent() );
+		InteractionCount[] received = federate.getMetrics().getInteractionsSent();
+		int grandTotal = 0;
+		for( InteractionCount classCount : received )
+			grandTotal += classCount.getCount();
+		
+		return MomEncodingHelpers.encode( type, grandTotal );
 	}
 
 	private byte[] getObjectsOwned( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		Set<ROCInstance> owned = federate.getMetrics().getObjectsOwned();
+		Set<Integer> owned = federate.getMetrics().getObjectsOwned();
 		return MomEncodingHelpers.encode( type, owned.size() );
 	}
 
 	private byte[] getObjectsUpdated( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		Set<ROCInstance> updated = federate.getMetrics().getObjectsUpdated();
-		return MomEncodingHelpers.encode( type, updated.size() );
+		ObjectClassBasedCount[] updated = federate.getMetrics().getObjectInstancesUpdated();
+		int grandTotal = 0;
+		for( ObjectClassBasedCount classCount : updated )
+			grandTotal += classCount.getCount();
+		
+		return MomEncodingHelpers.encode( type, grandTotal );
 	}
 
 	private byte[] getObjectsReflected( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		Set<ROCInstance> reflected = federate.getMetrics().getObjectsReflected();
-		return MomEncodingHelpers.encode( type, reflected.size() );
+		ObjectClassBasedCount[] reflected = federate.getMetrics().getObjectInstancesReflected();
+		int grandTotal = 0;
+		for( ObjectClassBasedCount classCount : reflected )
+			grandTotal += classCount.getCount();
+		
+		return MomEncodingHelpers.encode( type, grandTotal );
 	}
 
 	private byte[] getObjectInstancesDeleted( ACMetadata metadata )

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomFederate.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomFederate.java
@@ -311,19 +311,22 @@ public class MomFederate
 	private byte[] getObjectsOwned( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		return MomEncodingHelpers.encode( type, federate.getMetrics().getObjectsOwned() );
+		Set<ROCInstance> owned = federate.getMetrics().getObjectsOwned();
+		return MomEncodingHelpers.encode( type, owned.size() );
 	}
 
 	private byte[] getObjectsUpdated( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		return MomEncodingHelpers.encode( type, federate.getMetrics().getObjectsUpdated() );
+		Set<ROCInstance> updated = federate.getMetrics().getObjectsUpdated();
+		return MomEncodingHelpers.encode( type, updated.size() );
 	}
 
 	private byte[] getObjectsReflected( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		return MomEncodingHelpers.encode( type, federate.getMetrics().getObjectsReflected() );
+		Set<ROCInstance> reflected = federate.getMetrics().getObjectsReflected();
+		return MomEncodingHelpers.encode( type, reflected.size() );
 	}
 
 	private byte[] getObjectInstancesDeleted( ACMetadata metadata )

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomManager.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomManager.java
@@ -240,7 +240,8 @@ public class MomManager implements SaveRestoreTarget
 		if( sender != PorticoConstants.RTI_HANDLE )
 		{
 			Federate senderFederate = federation.getFederate( sender );
-			senderFederate.getMetrics().interactionSent();
+			int handle = interaction.getHandle();
+			senderFederate.getMetrics().interactionSent( handle );
 		}
 	}
 
@@ -250,7 +251,8 @@ public class MomManager implements SaveRestoreTarget
 			return;
 
 		Federate receiverFederate = federation.getFederate( receiver );
-		receiverFederate.getMetrics().interactionReceived();
+		int handle = interaction.getHandle(); // TODO Handle that the receiver will receive it as?
+		receiverFederate.getMetrics().interactionReceived( handle );
 	}
 
 	public void objectRegistered( int creator, ROCInstance instance )
@@ -261,7 +263,7 @@ public class MomManager implements SaveRestoreTarget
 		if( creator != PorticoConstants.RTI_HANDLE )
 		{
 			Federate senderFederate = federation.getFederate( creator );
-			senderFederate.getMetrics().objectRegistered( instance );
+			senderFederate.getMetrics().objectRegistered( instance.getHandle() );
 		}
 	}
 
@@ -282,7 +284,8 @@ public class MomManager implements SaveRestoreTarget
 		if( updator != PorticoConstants.RTI_HANDLE )
 		{
 			Federate updatingFederate = federation.getFederate( updator );
-			updatingFederate.getMetrics().sentUpdate( instance );
+			updatingFederate.getMetrics().sentUpdate( instance.getRegisteredClassHandle(), 
+			                                          instance.getHandle() );
 		}
 	}
 
@@ -292,7 +295,9 @@ public class MomManager implements SaveRestoreTarget
 			return;
 
 		Federate reflectingFederate = federation.getFederate( reflector );
-		reflectingFederate.getMetrics().reflectionReceived( instance );
+		OCMetadata discoveredAs = instance.getDiscoveredType( reflector );
+		reflectingFederate.getMetrics().reflectionReceived( discoveredAs.getHandle(), 
+		                                                    instance.getHandle() );
 	}
 
 	public void objectDeleted( int deletor, ROCInstance instance )
@@ -303,7 +308,7 @@ public class MomManager implements SaveRestoreTarget
 		if( deletor != PorticoConstants.RTI_HANDLE )
 		{
 			Federate deletingFederate = federation.getFederate( deletor );
-			deletingFederate.getMetrics().objectDeleted( instance );
+			deletingFederate.getMetrics().objectDeleted( instance.getHandle() );
 		}
 	}
 

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomManager.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomManager.java
@@ -23,6 +23,7 @@ import org.apache.logging.log4j.Logger;
 import org.portico.impl.HLAVersion;
 import org.portico.lrc.PorticoConstants;
 import org.portico.lrc.compat.JAttributeNotDefined;
+import org.portico.lrc.model.ICMetadata;
 import org.portico.lrc.model.Mom;
 import org.portico.lrc.model.OCMetadata;
 import org.portico.lrc.model.ObjectModel;
@@ -174,7 +175,8 @@ public class MomManager implements SaveRestoreTarget
 
 		// create a HLA object instance for the federate
 		Repository repository = this.federation.getRepository();
-		ROCInstance instance = repository.createObject( federateClass, federate.getFederateName(),
+		ROCInstance instance = repository.createObject( federateClass, 
+		                                                federate.getFederateName(),
 		                                                PorticoConstants.RTI_HANDLE,
 		                                                federateClass.getAllAttributeHandles() );
 		repository.addObject( instance );
@@ -197,7 +199,7 @@ public class MomManager implements SaveRestoreTarget
 
 		Set<Integer> subscribers = subscriptions.keySet();
 		for( int subscriber : subscribers )
-			this.objectDiscovered( subscriber, instance.getHandle() );
+			this.objectDiscovered( subscriber, instance );
 
 		if( subscriptions.size() > 0 )
 		{
@@ -224,12 +226,12 @@ public class MomManager implements SaveRestoreTarget
 		DeleteObject delete = new DeleteObject( objectInstanceHandle, new byte[0] );
 		Set<Integer> discoverers = removeInstance.getDiscoverers();
 		for( int discoverer : discoverers )
-			objectRemoved( discoverer, objectInstanceHandle );
+			objectRemoved( discoverer, removeInstance );
 
 		this.queueManycast( delete, removeInstance.getDiscoverers() );
 	}
 
-	public void interactionSent( int sender, int interactionId )
+	public void interactionSent( int sender, ICMetadata interaction )
 	{
 		if( !this.enabled )
 			return;
@@ -242,7 +244,7 @@ public class MomManager implements SaveRestoreTarget
 		}
 	}
 
-	public void interactionReceived( int receiver, int interactionId )
+	public void interactionReceived( int receiver, ICMetadata interaction )
 	{
 		if( !this.enabled )
 			return;
@@ -251,7 +253,7 @@ public class MomManager implements SaveRestoreTarget
 		receiverFederate.getMetrics().interactionReceived();
 	}
 
-	public void objectRegistered( int creator, int instanceId )
+	public void objectRegistered( int creator, ROCInstance instance )
 	{
 		if( !this.enabled )
 			return;
@@ -259,11 +261,11 @@ public class MomManager implements SaveRestoreTarget
 		if( creator != PorticoConstants.RTI_HANDLE )
 		{
 			Federate senderFederate = federation.getFederate( creator );
-			senderFederate.getMetrics().objectRegistered( instanceId );
+			senderFederate.getMetrics().objectRegistered( instance );
 		}
 	}
 
-	public void objectDiscovered( int discoverer, int instanceId )
+	public void objectDiscovered( int discoverer, ROCInstance instance )
 	{
 		if( !this.enabled )
 			return;
@@ -272,7 +274,7 @@ public class MomManager implements SaveRestoreTarget
 		subscriberFederate.getMetrics().objectDiscovered();
 	}
 
-	public void objectUpdated( int updator, int instanceId )
+	public void objectUpdated( int updator, ROCInstance instance )
 	{
 		if( !this.enabled )
 			return;
@@ -280,20 +282,20 @@ public class MomManager implements SaveRestoreTarget
 		if( updator != PorticoConstants.RTI_HANDLE )
 		{
 			Federate updatingFederate = federation.getFederate( updator );
-			updatingFederate.getMetrics().sentUpdate( instanceId );
+			updatingFederate.getMetrics().sentUpdate( instance );
 		}
 	}
 
-	public void objectReflected( int reflector, int instanceId )
+	public void objectReflected( int reflector, ROCInstance instance )
 	{
 		if( !this.enabled )
 			return;
 
 		Federate reflectingFederate = federation.getFederate( reflector );
-		reflectingFederate.getMetrics().reflectionReceived( instanceId );
+		reflectingFederate.getMetrics().reflectionReceived( instance );
 	}
 
-	public void objectDeleted( int deletor, int instanceId )
+	public void objectDeleted( int deletor, ROCInstance instance )
 	{
 		if( !this.enabled )
 			return;
@@ -301,11 +303,11 @@ public class MomManager implements SaveRestoreTarget
 		if( deletor != PorticoConstants.RTI_HANDLE )
 		{
 			Federate deletingFederate = federation.getFederate( deletor );
-			deletingFederate.getMetrics().objectDeleted( instanceId );
+			deletingFederate.getMetrics().objectDeleted( instance );
 		}
 	}
 
-	public void objectRemoved( int remover, int instanceId )
+	public void objectRemoved( int remover, ROCInstance instance )
 	{
 		if( !this.enabled )
 			return;

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/ObjectClassBasedCount.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/ObjectClassBasedCount.java
@@ -55,6 +55,7 @@ public class ObjectClassBasedCount implements DataElement
 	{
 		return 4;
 	}
+	
 	@Override
 	public void encode( ByteWrapper byteWrapper ) throws EncoderException
 	{
@@ -62,11 +63,13 @@ public class ObjectClassBasedCount implements DataElement
 		handle.encode( byteWrapper );
 		byteWrapper.putInt( count );
 	}
+	
 	@Override
 	public int getEncodedLength()
 	{
 		return HLA1516eHandle.EncodedLength + 4;
 	}
+	
 	@Override
 	public byte[] toByteArray() throws EncoderException
 	{
@@ -74,11 +77,13 @@ public class ObjectClassBasedCount implements DataElement
 		this.encode( wrapper );
 		return wrapper.array();
 	}
+	
 	@Override
 	public void decode( ByteWrapper byteWrapper ) throws DecoderException
 	{
 		throw new UnsupportedOperationException();
 	}
+	
 	@Override
 	public void decode( byte[] bytes ) throws DecoderException
 	{

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/ObjectClassBasedCount.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/ObjectClassBasedCount.java
@@ -1,0 +1,105 @@
+/*
+ *   Copyright 2018 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.rti.services.mom.data;
+
+import org.portico.impl.hla1516e.types.HLA1516eHandle;
+import org.portico.lrc.model.OCMetadata;
+
+import hla.rti1516e.encoding.ByteWrapper;
+import hla.rti1516e.encoding.DataElement;
+import hla.rti1516e.encoding.DecoderException;
+import hla.rti1516e.encoding.EncoderException;
+
+/**
+ * An immutable record of the number of instances of a particular object class.
+ * <p/>
+ * This class mirrors the HLAobjectClassBasedCount Fixed Record structure defined in the MOM 
+ */
+public class ObjectClassBasedCount implements DataElement
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private OCMetadata objectClass;
+	private int count;
+	
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public ObjectClassBasedCount( OCMetadata oc, int count )
+	{
+		this.objectClass = oc;
+		this.count = count;
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	public int getOctetBoundary()
+	{
+		return 4;
+	}
+	@Override
+	public void encode( ByteWrapper byteWrapper ) throws EncoderException
+	{
+		HLA1516eHandle handle = new HLA1516eHandle( objectClass.getHandle() );
+		handle.encode( byteWrapper );
+		byteWrapper.putInt( count );
+	}
+	@Override
+	public int getEncodedLength()
+	{
+		return HLA1516eHandle.EncodedLength + 4;
+	}
+	@Override
+	public byte[] toByteArray() throws EncoderException
+	{
+		ByteWrapper wrapper = new ByteWrapper( getEncodedLength() );
+		this.encode( wrapper );
+		return wrapper.array();
+	}
+	@Override
+	public void decode( ByteWrapper byteWrapper ) throws DecoderException
+	{
+		throw new UnsupportedOperationException();
+	}
+	@Override
+	public void decode( byte[] bytes ) throws DecoderException
+	{
+		throw new UnsupportedOperationException();
+	}
+
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+	public OCMetadata getObjectClass()
+	{
+		return this.objectClass;
+	}
+	
+	public int getCount()
+	{
+		return this.count;
+	}
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/incoming/MomUpdateAttributesHandler.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/incoming/MomUpdateAttributesHandler.java
@@ -60,10 +60,10 @@ public class MomUpdateAttributesHandler extends RTIMessageHandler
 		// Log update metrics
 		int sendingFederate = request.getSourceFederate();
 		int objectHandle = request.getObjectId();
-		momManager.objectUpdated( sendingFederate, objectHandle );
+		ROCInstance instance = repository.getObject( objectHandle );
+		momManager.objectUpdated( sendingFederate, instance );
 		
 		// Log reflect metrics
-		ROCInstance instance = repository.getObject( objectHandle );
 		InterestManager interests = federation.getInterestManager();
 		Set<Integer> subscribers = interests.getAllSubscribers( instance.getRegisteredType() );
 		for( int subscriber : subscribers )
@@ -71,7 +71,7 @@ public class MomUpdateAttributesHandler extends RTIMessageHandler
 			if( subscriber == sendingFederate )
 				continue;
 			
-			momManager.objectReflected( subscriber, objectHandle );
+			momManager.objectReflected( subscriber, instance );
 		}
 	}
 	

--- a/codebase/src/java/portico/org/portico2/rti/services/object/incoming/DeleteObjectHandler.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/object/incoming/DeleteObjectHandler.java
@@ -15,7 +15,6 @@
 package org.portico2.rti.services.object.incoming;
 
 import java.util.Map;
-import java.util.Set;
 
 import org.portico.lrc.compat.JConfigurationException;
 import org.portico.lrc.compat.JDeletePrivilegeNotHeld;
@@ -98,12 +97,11 @@ public class DeleteObjectHandler extends RTIMessageHandler
 		repository.deleteObject( objectHandle );
 		context.success();
 		
-		Set<Integer> discoverers = instance.getDiscoverers();
-		logMetrics( sourceFederate, objectHandle, discoverers );
+		logMetrics( sourceFederate, instance );
 		
 		// find the federates that know about this object and tell them
 		DeleteObject copy = request.clone( DeleteObject.class );
-		queueManycast( copy, discoverers );
+		queueManycast( copy, instance.getDiscoverers() );
 		
 		if( logger.isInfoEnabled() )
 		{
@@ -120,21 +118,20 @@ public class DeleteObjectHandler extends RTIMessageHandler
 	 * removed notification.
 	 * 
 	 * @param deletor the id of the federate deleting the object instance 
-	 * @param objectHandle the id of the object instance being deleted
-	 * @param discoverers the ids of all federates that will receive the removed notification
+	 * @param instance the object instance being deleted
 	 */
-	private void logMetrics( int deletor, int objectHandle, Set<Integer> discoverers )
+	private void logMetrics( int deletor, ROCInstance instance )
 	{
 		// objectDeleted from sending federate
-		momManager.objectDeleted( deletor, objectHandle );
+		momManager.objectDeleted( deletor, instance );
 		
 		// objectRemoved on all target federates
-		for( int discoverer : discoverers )
+		for( int discoverer : instance.getDiscoverers() )
 		{
 			if( discoverer == deletor )
 				continue;
 			
-			momManager.objectRemoved( discoverer, objectHandle );
+			momManager.objectRemoved( discoverer, instance );
 		}
 	}
 	//----------------------------------------------------------

--- a/codebase/src/java/portico/org/portico2/rti/services/object/incoming/RegisterObjectHandler.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/object/incoming/RegisterObjectHandler.java
@@ -89,7 +89,7 @@ public class RegisterObjectHandler extends RTIMessageHandler
 		int instanceHandle = newInstance.getHandle();
 		
 		// Log registrant metrics
-		momManager.objectRegistered( federateHandle, instanceHandle );
+		momManager.objectRegistered( federateHandle, newInstance );
 
 		// TODO Region Support
 
@@ -117,7 +117,7 @@ public class RegisterObjectHandler extends RTIMessageHandler
 			
 			// Log discovery metrics
 			if( federateHandle != subscriberHandle)
-				momManager.objectDiscovered( subscriberHandle, instanceHandle );
+				momManager.objectDiscovered( subscriberHandle, newInstance );
 		}
 
 		DiscoverObject discover = fill( new DiscoverObject(newInstance), federateHandle );

--- a/codebase/src/java/portico/org/portico2/rti/services/object/incoming/RegisterObjectHandler.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/object/incoming/RegisterObjectHandler.java
@@ -113,7 +113,8 @@ public class RegisterObjectHandler extends RTIMessageHandler
 		Map<Integer,OCMetadata> subscriptions = interests.getAllSubscribersWithTypes( objectClass );
 		for( Integer subscriberHandle : subscriptions.keySet() )
 		{
-			newInstance.discover( subscriberHandle, subscriptions.get(subscriberHandle) );
+			OCMetadata discoveredAs = subscriptions.get( subscriberHandle );
+			newInstance.discover( subscriberHandle, discoveredAs );
 			
 			// Log discovery metrics
 			if( federateHandle != subscriberHandle)

--- a/codebase/src/java/portico/org/portico2/rti/services/pubsub/incoming/SubscribeObjectClassHandler.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/pubsub/incoming/SubscribeObjectClassHandler.java
@@ -120,7 +120,7 @@ public class SubscribeObjectClassHandler extends RTIMessageHandler
 			discover.setImmediateProcessingFlag( false );
 			
 			// Update discovery metrics
-			momManager.objectDiscovered( federateHandle, instance.getHandle() );
+			momManager.objectDiscovered( federateHandle, instance );
 			
 			super.queueUnicast( discover, federateHandle );
 			if( logger.isDebugEnabled() )


### PR DESCRIPTION
This PR contains work done for tickets #231, #232, #233 and #234 

## MOM support for request/report publications and subscriptions #231
- Adds support for `HLAfederate.HLArequest.HLArequestPublications` and its corresponding response interactions `HLAfederate.HLAreport.HLAreportObjectClassPublication` and `HLAfederate.HLAreport.HLAreportInteractionPublication`
- Adds support for `HLAfederate.HLArequest.HLArequestSubscriptions` and its corresponding response interactions `HLAfederate.HLAreport.HLAreportObjectClassSubscription` and
 `HLAfederate.HLAreport.HLAreportInteractionSubscription`

## MOM support for request/report object instances that can be deleted #232
- Adds support for MOM interaction `HLAfederate.HLArequest.HLArequestObjectInstancesThatCanBeDeleted` and its
  corresponding response `HLAfederate.HLAreport.HLAreportObjectInstancesThatCanBeDeleted`

## MOM support for request/report object instances updated and reflected #233
- Adds support for MOM interaction `HLAfederate.HLArequest.HLArequestObjectInstancesUpdated`
  and its corresponding response `HLAfederate.HLAreport.HLAreportObjectInstancesUpdated`
- Adds support for MOM interaction `HLAfederate.HLArequest.HLArequestObjectInstancesReflected` and its corresponding response `HLAfederate.HLAreport.HLAreportObjectInstancesReflected`

## MOM support for request/report updates and interactions sent and received #234
- Adds support for MOM interaction `HLAfederate.HLArequest.HLArequestUpdatesSent` and its corresponding response `HLAfederate.HLAreport.HLAreportUpdatesSent`
- Adds support for MOM interaction `HLAfederate.HLArequest.HLArequestInteractionsSent` and its corresponding response `HLAfederate.HLAreport.HLAreportInteractionsSent`
- Adds support for MOM interaction `HLAfederate.HLArequest.HLArequestReflectionsReceived` and its corresponding response `HLAfederate.HLAreport.HLAreportReflectionsReceived`
- Adds support for MOM interaction `HLAfederate.HLArequest.HLArequestInteractionsReceived` and its corresponding response `HLAfederate.HLAreport.HLAreportInteractionsReceived`

## MOM support for request/report object instance information #235

- Adds support for MOM interaction `HLAfederate.HLArequest.HLArequestObjectInstanceInformation` and its corresponding response `HLAfederate.HLAreport.HLAreportObjectInstanceInformation`