### PR TITLE
MOM support for service invocation information and exceptions #237

### DIFF
--- a/codebase/src/java/portico/org/portico/impl/hla1516e/Impl1516eHelper.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516e/Impl1516eHelper.java
@@ -49,7 +49,9 @@ import org.portico.lrc.compat.JTimeAdvanceAlreadyInProgress;
 import org.portico.lrc.model.ObjectModel;
 import org.portico.utils.StringUtils;
 import org.portico2.common.configuration.RID;
+import org.portico2.common.messaging.ErrorResponse;
 import org.portico2.common.messaging.MessageContext;
+import org.portico2.common.messaging.ResponseMessage;
 import org.portico2.lrc.LRC;
 import org.portico2.lrc.LRCState;
 /**
@@ -430,6 +432,59 @@ public class Impl1516eHelper implements ISpecHelper
 //		this.lrc.reinitialize();
 	}
 
+	/**
+	 * Reports the result of an RTIambassador service invocation to the federation via the MOM
+	 * 
+	 * @param serviceName the name of the service invoked
+	 * @param response the response from the RTI
+	 * @param parameters the parameters the service was invoked with
+	 */
+	public void reportServiceInvocation( String serviceName,
+	                                     ResponseMessage response,
+	                                     Object... parameters )
+	{
+		boolean reporting = this.state.isServiceReporting() || this.state.isExceptionReporting();
+		if( !reporting )
+			return;
+		
+		boolean success = response.isSuccess();
+		Object returnValue = success ? response.getResult() : null;
+		String errorMessage = !success ? ((ErrorResponse)response).getCause().getMessage() : null;
+		
+		this.lrc.reportServiceInvocation( serviceName, 
+		                                  success, 
+		                                  returnValue, 
+		                                  errorMessage, 
+		                                  parameters );
+	}
+	
+	/**
+	 * Reports the result of a service invocation to the federation via the MOM
+	 * 
+	 * @param serviceName the name of the service invoked
+	 * @param success whether the service invocation was successful
+	 * @param result if the <code>success</code> parameter is <code>true</code> this value will be 
+	 *               interpreted as the value the service invocation returned. If the <code>success</code>
+	 *               parameter is <code>false</code> this value will be interpreted as the error message 
+	 *               that was raised
+	 * @param parameters the parameters the service was invoked with
+	 */
+	public void reportServiceInvocation( String serviceName,
+	                                     boolean success,
+	                                     Object result,
+	                                     Object... parameters )
+	{
+		boolean reporting = this.state.isServiceReporting() || this.state.isExceptionReporting();
+		if( !reporting )
+			return;
+		
+		this.lrc.reportServiceInvocation( serviceName, 
+		                                  success, 
+		                                  success ? result : null, 
+		                                  !success ? result.toString() : null, 
+		                                  parameters );
+	}
+	
 	//----------------------------------------------------------
 	//                     STATIC METHODS
 	//----------------------------------------------------------

--- a/codebase/src/java/portico/org/portico/impl/hla1516e/Rti1516eAmbassador.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516e/Rti1516eAmbassador.java
@@ -746,10 +746,15 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		///////////////////////////////////////////////////////
 		RegisterSyncPoint request = new RegisterSyncPoint( label, userSuppliedTag );
 		ResponseMessage response = processMessage( request );
-
+		
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "registerFederationSynchronizationPoint", 
+		                                response, 
+		                                label,
+		                                userSuppliedTag );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -804,10 +809,16 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 			set = HLA1516eFederateHandleSet.toJavaSet( synchronizationSet );
 		RegisterSyncPoint request = new RegisterSyncPoint( label, tag, set );
 		ResponseMessage response = processMessage( request );
-
+		
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "registerFederationSynchronizationPoint", 
+		                                response, 
+		                                label,
+		                                tag,
+		                                synchronizationSet );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -856,10 +867,14 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		///////////////////////////////////////////////////////
 		SyncPointAchieved request = new SyncPointAchieved( synchronizationPointLabel );
 		ResponseMessage response = processMessage( request );
-
+		
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "synchronizationPointAchieved", 
+		                                response, 
+		                                synchronizationPointLabel );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -917,6 +932,11 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "synchronizationPointAchieved", 
+		                                response, 
+		                                synchronizationPointLabel,
+		                                successIndicator );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -1113,6 +1133,11 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "publishObjectClassAttributes", 
+		                                response, 
+		                                theClass,
+		                                attributeList );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -1174,6 +1199,10 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "unpublishObjectClass", 
+		                                response, 
+		                                theClass );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -1243,6 +1272,11 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "unpublishObjectClassAttributes", 
+		                                response, 
+		                                theClass,
+		                                attributeList );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -1312,6 +1346,10 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "publishInteractionClass", 
+		                                response, 
+		                                theInteraction );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -1369,6 +1407,10 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "unpublishInteractionClass", 
+		                                response, 
+		                                theInteraction );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -1433,6 +1475,11 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "subscribeObjectClassAttributes", 
+		                                response, 
+		                                theClass,
+		                                attributeList );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -1544,6 +1591,10 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "unsubscribeObjectClass", 
+		                                response, 
+		                                theClass );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -1608,6 +1659,11 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "unsubscribeObjectClassAttributes", 
+		                                response, 
+		                                theClass,
+		                                attributeList );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -1674,6 +1730,10 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "subscribeInteractionClass", 
+		                                response, 
+		                                theClass );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -1748,6 +1808,10 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "unsubscribeInteractionClass", 
+		                                response, 
+		                                theClass );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -1811,6 +1875,10 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "reserveObjectInstanceName", 
+		                                response, 
+		                                theObjectName );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -1905,6 +1973,10 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "registerObjectInstance", 
+		                                response, 
+		                                theClass );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -1973,6 +2045,11 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "registerObjectInstance", 
+		                                response, 
+		                                theClass,
+		                                theObjectName );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -2046,6 +2123,12 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "updateAttributeValues", 
+		                                response, 
+		                                theObject,
+		                                theAttributes,
+		                                tag );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -2126,6 +2209,13 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "updateAttributeValues", 
+		                                response, 
+		                                theObject,
+		                                theAttributes,
+		                                tag,
+		                                theTime );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -2201,6 +2291,12 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "sendInteraction", 
+		                                response, 
+		                                theInteraction,
+		                                theParameters,
+		                                tag );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -2280,6 +2376,13 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "sendInteraction", 
+		                                response, 
+		                                theInteraction,
+		                                theParameters,
+		                                tag,
+		                                theTime );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -2351,6 +2454,11 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "deleteObjectInstance", 
+		                                response, 
+		                                objectHandle,
+		                                userSuppliedTag );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -2423,6 +2531,12 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "deleteObjectInstance", 
+		                                response, 
+		                                objectHandle,
+		                                userSuppliedTag,
+		                                theTime );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -2490,6 +2604,10 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "localDeleteObjectInstance", 
+		                                response, 
+		                                objectHandle );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -2558,6 +2676,12 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "requestAttributeValueUpdate", 
+		                                response, 
+		                                theObject,
+		                                theAttributes,
+		                                tag );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -2627,6 +2751,12 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "requestAttributeValueUpdate", 
+		                                response, 
+		                                theClass,
+		                                theAttributes,
+		                                tag );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -2761,6 +2891,11 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "unconditionalAttributeOwnershipDivestiture", 
+		                                response, 
+		                                theObject,
+		                                theAttributes );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -2837,6 +2972,12 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "negotiatedAttributeOwnershipDivestiture", 
+		                                response, 
+		                                theObject,
+		                                theAttributes,
+		                                userSuppliedTag );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -2936,6 +3077,12 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "attributeOwnershipAcquisition", 
+		                                response, 
+		                                theObject,
+		                                desiredAttributes,
+		                                userSuppliedTag );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -3021,6 +3168,11 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "attributeOwnershipAcquisitionIfAvailable", 
+		                                response, 
+		                                theObject,
+		                                desiredAttributes );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -3126,6 +3278,11 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "attributeOwnershipDivestitureIfWanted", 
+		                                response, 
+		                                theObject,
+		                                theAttributes );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -3204,6 +3361,11 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "cancelNegotiatedAttributeOwnershipDivestiture", 
+		                                response, 
+		                                theObject,
+		                                theAttributes );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -3283,6 +3445,11 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "cancelAttributeOwnershipAcquisition", 
+		                                response, 
+		                                theObject,
+		                                theAttributes );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -3360,6 +3527,11 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "queryAttributeOwnership", 
+		                                response, 
+		                                theObject,
+		                                theAttribute );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -3468,6 +3640,10 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "enableTimeRegulation", 
+		                                response, 
+		                                theLookahead );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -3540,6 +3716,9 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "disableTimeRegulation", 
+		                                response );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -3598,6 +3777,9 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "enableTimeConstrained", 
+		                                response );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -3662,6 +3844,9 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "disableTimeConstrained", 
+		                                response );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -3728,6 +3913,10 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "timeAdvanceRequest", 
+		                                response,
+		                                theTime );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -3811,6 +4000,10 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "timeAdvanceRequestAvailable", 
+		                                response,
+		                                theTime );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -3893,6 +4086,10 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "nextMessageRequest", 
+		                                response,
+		                                theTime );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -3975,6 +4172,10 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "nextMessageRequestAvailable", 
+		                                response,
+		                                theTime );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -4057,6 +4258,10 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "flushQueueRequest", 
+		                                response,
+		                                theTime );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -4128,6 +4333,9 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "enableAsynchronousDelivery", 
+		                                response );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -4183,6 +4391,9 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "disableAsynchronousDelivery", 
+		                                response );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -4238,6 +4449,9 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "queryGALT", 
+		                                response );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -4286,7 +4500,11 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		helper.checkSave();
 		helper.checkRestore();
 		
-		return new DoubleTime( helper.getState().getCurrentTime() );
+		DoubleTime result = new DoubleTime( helper.getState().getCurrentTime() );
+		
+		helper.reportServiceInvocation( "queryLogicalTime", true, result );
+		
+		return result;
 	}
 
 	// 8.18
@@ -4302,7 +4520,11 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		helper.checkRestore();
 		
 		DoubleTime time = new DoubleTime( helper.getState().getCurrentTime() );
-		return new TimeQueryReturn( true, time );
+		TimeQueryReturn result = new TimeQueryReturn( true, time );
+		
+		helper.reportServiceInvocation( "queryLITS", true, result );
+		
+		return result;
 	}
 
 	// 8.19
@@ -4338,6 +4560,10 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		////////////////////////////
 		// 2. process the results //
 		////////////////////////////
+		helper.reportServiceInvocation( "modifyLookahead", 
+		                                response,
+		                                theLookahead );
+		
 		// check to see if we got an error or a success
 		if( response.isError() == false )
 		{
@@ -4397,7 +4623,11 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		helper.checkSave();
 		helper.checkRestore();
 		
-		return new DoubleTimeInterval( helper.getState().getLookahead() );
+		DoubleTimeInterval result = new DoubleTimeInterval( helper.getState().getLookahead() );
+		
+		helper.reportServiceInvocation( "queryLookahead", true, result );
+		
+		return result;
 	}
 
 	// 8.21
@@ -4831,11 +5061,14 @@ return "";
 		OCMetadata cls = helper.getFOM().getObjectClass( theName );
 		if( cls == null )
 		{
+			helper.reportServiceInvocation( "getObjectClassHandle", false, "name not found", theName );
 			throw new NameNotFound( theName );
 		}
 		else
 		{
-			return new HLA1516eHandle( cls.getHandle() );
+			ObjectClassHandle result = new HLA1516eHandle( cls.getHandle() );
+			helper.reportServiceInvocation( "getObjectClassHandle", true, result, theName );
+			return result;
 		}
 	}
 
@@ -4853,11 +5086,14 @@ return "";
 		OCMetadata cls = helper.getFOM().getObjectClass( handle );
 		if( cls == null )
 		{
+			helper.reportServiceInvocation( "getObjectClassName", false, "unknown handle", theHandle );
 			throw new RTIinternalError( "unknown handle: " + theHandle );
 		}
 		else
 		{
-			return cls.getQualifiedName();
+			String result = cls.getQualifiedName();
+			helper.reportServiceInvocation( "getObjectClassName", true, result, theHandle );
+			return result;
 		}
 	}
 
@@ -4871,9 +5107,22 @@ return "";
 		helper.checkJoined();
 		LOCInstance instance = helper.getState().getRepository().getObject( theObject.hashCode() );
 		if( instance == null )
+		{
+			helper.reportServiceInvocation( "getKnownObjectClassHandle", 
+			                                false, 
+			                                "object instance not known", 
+			                                theObject );
 			throw new ObjectInstanceNotKnown( "handle: " + theObject );
+		}
 		else
-			return new HLA1516eHandle( instance.getDiscoveredClassHandle() );
+		{
+			ObjectClassHandle result = new HLA1516eHandle( instance.getDiscoveredClassHandle() );
+			helper.reportServiceInvocation( "getKnownObjectClassHandle", 
+			                                true, 
+			                                result, 
+			                                theObject );
+			return result;
+		}
 	}
 
 	// 10.9
@@ -4933,17 +5182,33 @@ return "";
 		OCMetadata cls = helper.getFOM().getObjectClass( cHandle );
 		if( cls == null )
 		{
+			helper.reportServiceInvocation( "getAttributeHandle", 
+			                                false, 
+			                                "invalid object class handle", 
+			                                whichClass,
+			                                theName );
 			throw new InvalidObjectClassHandle( "handle: " + whichClass );
 		}
 		
 		ACMetadata aClass = helper.getFOM().getAttributeClass( cHandle, theName );
 		if( aClass == null )
 		{
+			helper.reportServiceInvocation( "getAttributeHandle", 
+			                                false, 
+			                                "name not found", 
+			                                whichClass,
+			                                theName );
 			throw new NameNotFound( "name: " + theName );
 		}
 		else
 		{
-			return new HLA1516eHandle( aClass.getHandle() );
+			AttributeHandle result = new HLA1516eHandle( aClass.getHandle() );
+			helper.reportServiceInvocation( "getAttributeHandle", 
+			                                true, 
+			                                result, 
+			                                whichClass,
+			                                theName );
+			return result;
 		}
 	}
 
@@ -4968,14 +5233,16 @@ return "";
 		else
 		{
 			String name = cls.getAttributeName( acHandle );
+			helper.reportServiceInvocation( "getAttributeName", 
+			                                name != null, 
+			                                name != null ? name : "attribute not defined", 
+			                                whichClass,
+			                                theHandle );
+			
 			if( name == null )
-			{
 				throw new AttributeNotDefined( "handle: " + theHandle );
-			}
 			else
-			{
 				return name;
-			}
 		}
 	}
 
@@ -5014,6 +5281,11 @@ return "";
 		
 		// get the class
 		ICMetadata cls = helper.getFOM().getInteractionClass( theName );
+		helper.reportServiceInvocation( "getInteractionClassHandle", 
+		                                cls != null, 
+		                                cls != null ? cls.getHandle() : "name not found", 
+		                                theName );
+		
 		if( cls == null )
 		{
 			throw new NameNotFound( theName );
@@ -5036,9 +5308,14 @@ return "";
 		// get the class
 		int handle = HLA1516eHandle.validatedHandle( theHandle );
 		ICMetadata cls = helper.getFOM().getInteractionClass( handle );
+		helper.reportServiceInvocation( "getInteractionClassName", 
+		                                cls != null, 
+		                                cls != null ? cls.getQualifiedName() : "invalid interaction class handle", 
+		                                theHandle );
+		
 		if( cls == null )
 		{
-			throw new RTIinternalError( "handle: " + theHandle );
+			throw new InvalidInteractionClassHandle( "handle: " + theHandle );
 		}
 		else
 		{
@@ -5060,18 +5337,34 @@ return "";
 		ICMetadata cls = helper.getFOM().getInteractionClass( cHandle );
 		if( cls == null )
 		{
-			throw new RTIinternalError( "handle: " + cHandle );
+			helper.reportServiceInvocation( "getParameterHandle", 
+			                                false, 
+			                                "invalid interaction class handle", 
+			                                whichClass,
+			                                theName );
+			throw new InvalidInteractionClassHandle( "handle: " + cHandle );
 		}
 		else
 		{
 			int handle = cls.getParameterHandle( theName );
 			if( handle == ObjectModel.INVALID_HANDLE )
 			{
+				helper.reportServiceInvocation( "getParameterHandle", 
+				                                false, 
+				                                "parameter name not found", 
+				                                whichClass,
+				                                theName );
 				throw new NameNotFound( "name: " + theName );
 			}
 			else
 			{
-				return new HLA1516eHandle( handle );
+				ParameterHandle result = new HLA1516eHandle( handle );
+				helper.reportServiceInvocation( "getParameterHandle", 
+				                                true, 
+				                                result, 
+				                                whichClass,
+				                                theName );
+				return result;
 			}
 		}
 	}
@@ -5092,17 +5385,32 @@ return "";
 		ICMetadata cls = helper.getFOM().getInteractionClass( icHandle );
 		if( cls == null )
 		{
-			throw new RTIinternalError( "handle: " + icHandle );
+			helper.reportServiceInvocation( "getParameterHandle", 
+			                                false, 
+			                                "invalid interaction class handle", 
+			                                whichClass,
+			                                theHandle );
+			throw new InvalidInteractionClassHandle( "handle: " + icHandle );
 		}
 		else
 		{
 			String name = cls.getParameterName( pcHandle );
 			if( name == null )
 			{
+				helper.reportServiceInvocation( "getParameterHandle", 
+				                                false, 
+				                                "parameter not defined", 
+				                                whichClass,
+				                                theHandle );
 				throw new InteractionParameterNotDefined( "handle: " + pcHandle );
 			}
 			else
 			{
+				helper.reportServiceInvocation( "getParameterHandle", 
+				                                true, 
+				                                name, 
+				                                whichClass,
+				                                theHandle );
 				return name;
 			}
 		}
@@ -5375,7 +5683,23 @@ return "";
 	    throws CallNotAllowedFromWithinCallback,
 	           RTIinternalError
 	{
-		return helper.evokeSingle( approximateMinimumTimeInSeconds );
+		try
+		{
+			boolean result = helper.evokeSingle( approximateMinimumTimeInSeconds );
+			this.helper.reportServiceInvocation( "evokeCallback", 
+			                                     true, 
+			                                     result, 
+			                                     approximateMinimumTimeInSeconds );
+			return result;
+		}
+		catch ( CallNotAllowedFromWithinCallback cnafwc )
+		{
+			this.helper.reportServiceInvocation( "evokeCallback", 
+			                                     false, 
+			                                     "call not allowed from within callback", 
+			                                     approximateMinimumTimeInSeconds );
+			throw cnafwc;
+		}
 	}
 
 	// 10.42
@@ -5384,8 +5708,26 @@ return "";
 	    throws CallNotAllowedFromWithinCallback,
 	           RTIinternalError
 	{
-		return helper.evokeMultiple( approximateMinimumTimeInSeconds,
-		                             approximateMaximumTimeInSeconds );
+		try
+		{
+			boolean result = helper.evokeMultiple( approximateMinimumTimeInSeconds,
+			                                       approximateMaximumTimeInSeconds );
+			this.helper.reportServiceInvocation( "evokeMultipleCallbacks", 
+			                                     true, 
+			                                     result, 
+			                                     approximateMinimumTimeInSeconds,
+			                                     approximateMaximumTimeInSeconds );
+			
+			return result;
+		}
+		catch( CallNotAllowedFromWithinCallback cnafwc )
+		{
+			this.helper.reportServiceInvocation( "evokeMultipleCallbacks", 
+			                                     false, 
+			                                     "call not allowed from within callback", 
+			                                     approximateMinimumTimeInSeconds );
+			throw cnafwc;
+		}
 	}
 
 	// 10.43
@@ -5394,6 +5736,9 @@ return "";
 		helper.checkSave();
 		helper.checkRestore();
 		helper.getState().setCallbacksEnabled( true );
+		
+		this.helper.reportServiceInvocation( "enableCallbacks", true, null );
+		
 		logger().debug( "enableCallbacks invoked(): callbacks turned on" );
 	}
 
@@ -5403,6 +5748,9 @@ return "";
 		helper.checkSave();
 		helper.checkRestore();
 		helper.getState().setCallbacksEnabled( false );
+		
+		this.helper.reportServiceInvocation( "disableCallbacks", true, null );
+		
 		logger().debug( "disableCallbacks invoked(): callbacks turned off" );
 	}
 

--- a/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/AttributeReleaseRequestCallbackHandler.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/AttributeReleaseRequestCallbackHandler.java
@@ -23,6 +23,8 @@ import org.portico.lrc.compat.JConfigurationException;
 import org.portico2.common.messaging.MessageContext;
 import org.portico2.common.services.ownership.msg.AttributeAcquire;
 
+import hla.rti1516e.AttributeHandleSet;
+import hla.rti1516e.ObjectInstanceHandle;
 import hla.rti1516e.exceptions.FederateInternalError;
 
 public class AttributeReleaseRequestCallbackHandler extends LRC1516eCallbackHandler
@@ -52,8 +54,9 @@ public class AttributeReleaseRequestCallbackHandler extends LRC1516eCallbackHand
 	public void callback( MessageContext context ) throws FederateInternalError
 	{
 		AttributeAcquire callback = context.getRequest( AttributeAcquire.class, this );
-		int objectHandle = callback.getObjectHandle();
+		ObjectInstanceHandle objectHandle = new HLA1516eHandle( callback.getObjectHandle() );
 		Set<Integer> attributes = callback.getAttributes();
+		AttributeHandleSet ahs = new HLA1516eAttributeHandleSet( attributes );
 		byte[] tag = callback.getTag();
 		
 		if( logger.isTraceEnabled() )
@@ -62,10 +65,15 @@ public class AttributeReleaseRequestCallbackHandler extends LRC1516eCallbackHand
 			              ",attributes="+attributes+",tagsize="+tag.length+")" );
 		}
 		
-		fedamb().requestAttributeOwnershipRelease( new HLA1516eHandle(objectHandle),
-		                                           new HLA1516eAttributeHandleSet(attributes),
+		fedamb().requestAttributeOwnershipRelease( objectHandle,
+		                                           ahs,
 		                                           tag );
-		
+		helper.reportServiceInvocation( "requestAttributeOwnershipRelease", 
+		                                true, 
+		                                null,
+		                                objectHandle, 
+		                                ahs, 
+		                                tag );
 		context.success();
 		
 		if( logger.isTraceEnabled() )

--- a/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/AttributesAcquiredCallbackHandler.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/AttributesAcquiredCallbackHandler.java
@@ -23,6 +23,8 @@ import org.portico.lrc.compat.JConfigurationException;
 import org.portico.lrc.services.ownership.msg.OwnershipAcquired;
 import org.portico2.common.messaging.MessageContext;
 
+import hla.rti1516e.AttributeHandleSet;
+import hla.rti1516e.ObjectInstanceHandle;
 import hla.rti1516e.exceptions.FederateInternalError;
 
 public class AttributesAcquiredCallbackHandler extends LRC1516eCallbackHandler
@@ -53,8 +55,9 @@ public class AttributesAcquiredCallbackHandler extends LRC1516eCallbackHandler
 	{
 		OwnershipAcquired acquired = context.getRequest( OwnershipAcquired.class, this );
 		vetoUnlessFromUs( acquired );
-		int objectHandle = acquired.getObjectHandle();
+		ObjectInstanceHandle objectHandle = new HLA1516eHandle( acquired.getObjectHandle() );
 		Set<Integer> attributes = acquired.getAttributeHandles();
+		AttributeHandleSet handleSet = new HLA1516eAttributeHandleSet( attributes );
 
 		if( logger.isTraceEnabled() )
 		{
@@ -62,11 +65,15 @@ public class AttributesAcquiredCallbackHandler extends LRC1516eCallbackHandler
 			              ",attributes="+attributes+")" );
 		}
 
-		HLA1516eAttributeHandleSet handleSet = new HLA1516eAttributeHandleSet( attributes );
-		fedamb().attributeOwnershipAcquisitionNotification( new HLA1516eHandle(objectHandle),
+		
+		fedamb().attributeOwnershipAcquisitionNotification( objectHandle,
 		                                                    handleSet,
 		                                                    null );
-		
+		helper.reportServiceInvocation( "attributeOwnershipAcquisitionNotification", 
+		                                true, 
+		                                null, 
+		                                objectHandle,
+		                                handleSet );
 		logger.trace( "         attributeOwnershipAcquisitionNotification() callback complete" );
 	}
 

--- a/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/AttributesUnavailableCallbackHandler.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/AttributesUnavailableCallbackHandler.java
@@ -23,6 +23,8 @@ import org.portico.lrc.compat.JConfigurationException;
 import org.portico.lrc.services.ownership.msg.AttributesUnavailable;
 import org.portico2.common.messaging.MessageContext;
 
+import hla.rti1516e.AttributeHandleSet;
+import hla.rti1516e.ObjectInstanceHandle;
 import hla.rti1516e.exceptions.FederateInternalError;
 
 public class AttributesUnavailableCallbackHandler extends LRC1516eCallbackHandler
@@ -53,8 +55,9 @@ public class AttributesUnavailableCallbackHandler extends LRC1516eCallbackHandle
 	{
 		AttributesUnavailable unavailable = context.getRequest( AttributesUnavailable.class, this );
 		vetoUnlessFromUs( unavailable );
-		int objectHandle = unavailable.getObjectHandle();
+		ObjectInstanceHandle objectHandle = new HLA1516eHandle( unavailable.getObjectHandle() );
 		Set<Integer> attributes = unavailable.getAttributeHandles();
+		AttributeHandleSet handleSet = new HLA1516eAttributeHandleSet( attributes );
 		
 		if( logger.isTraceEnabled() )
 		{
@@ -62,8 +65,13 @@ public class AttributesUnavailableCallbackHandler extends LRC1516eCallbackHandle
 			              ",attributes="+attributes+")" );
 		}
 
-		HLA1516eAttributeHandleSet handleSet = new HLA1516eAttributeHandleSet( attributes );
-		fedamb().attributeOwnershipUnavailable( new HLA1516eHandle(objectHandle), handleSet );
+		
+		fedamb().attributeOwnershipUnavailable( objectHandle, handleSet );
+		helper.reportServiceInvocation( "attributeOwnershipUnavailable", 
+		                                true, 
+		                                null, 
+		                                objectHandle, 
+		                                handleSet );
 		
 		context.success();
 		

--- a/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/DiscoverObjectCallbackHandler.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/DiscoverObjectCallbackHandler.java
@@ -66,6 +66,12 @@ public class DiscoverObjectCallbackHandler extends LRC1516eCallbackHandler
 		ObjectInstanceHandle oHandle = new HLA1516eHandle( objectHandle );
 		ObjectClassHandle cHandle = new HLA1516eHandle( classHandle );
 		fedamb().discoverObjectInstance( oHandle, cHandle, objectName );
+		helper.reportServiceInvocation( "discoverObjectInstance", 
+		                                true, 
+		                                null, 
+		                                oHandle, 
+		                                cHandle, 
+		                                objectName );
 		context.success();
 		
 		if( logger.isTraceEnabled() )

--- a/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/FederationSynchronizedCallbackHandler.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/FederationSynchronizedCallbackHandler.java
@@ -21,6 +21,7 @@ import org.portico.lrc.compat.JConfigurationException;
 import org.portico2.common.messaging.MessageContext;
 import org.portico2.common.services.sync.msg.FederationSynchronized;
 
+import hla.rti1516e.FederateHandleSet;
 import hla.rti1516e.exceptions.FederateInternalError;
 
 public class FederationSynchronizedCallbackHandler extends LRC1516eCallbackHandler
@@ -54,8 +55,13 @@ public class FederationSynchronizedCallbackHandler extends LRC1516eCallbackHandl
 
 		// let the fedamb know
 		logger.trace( "CALLBACK federationSynchronized(label="+label+")" );
-		fedamb().federationSynchronized( label, new HLA1516eFederateHandleSet() );
-
+		FederateHandleSet federates = new HLA1516eFederateHandleSet();
+		fedamb().federationSynchronized( label, federates );
+		helper.reportServiceInvocation( "federationSynchronized", 
+		                                true, 
+		                                null, 
+		                                label,
+		                                federates);
 		logger.trace( "         federationSynchronized() callback complete" );
 		context.success();
 	}

--- a/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/ObjectNameReservationCallbackHandler.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/ObjectNameReservationCallbackHandler.java
@@ -58,6 +58,7 @@ public class ObjectNameReservationCallbackHandler extends LRC1516eCallbackHandle
 				logger.trace( "CALLBACK objectInstanceNameReservationSucceeded(name="+name+")" );
 
 			fedamb().objectInstanceNameReservationSucceeded( name );
+			helper.reportServiceInvocation( "objectInstanceNameReservationSucceeded", true, null, name );
 			
 			if( logger.isTraceEnabled() )
 				logger.trace( "         objectInstanceNameReservationSucceeded() callback complete" );
@@ -68,6 +69,7 @@ public class ObjectNameReservationCallbackHandler extends LRC1516eCallbackHandle
 				logger.trace( "CALLBACK objectInstanceNameReservationFailed(name="+name+")" );
 
 			fedamb().objectInstanceNameReservationFailed( name );
+			helper.reportServiceInvocation( "objectInstanceNameReservationFailed", true, null, name );
 			
 			if( logger.isTraceEnabled() )
 				logger.trace( "         objectInstanceNameReservationFailed() callback complete" );

--- a/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/ProvideUpdateCallbackHandler.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/ProvideUpdateCallbackHandler.java
@@ -23,6 +23,8 @@ import org.portico.lrc.compat.JConfigurationException;
 import org.portico2.common.messaging.MessageContext;
 import org.portico2.common.services.object.msg.RequestObjectUpdate;
 
+import hla.rti1516e.AttributeHandleSet;
+import hla.rti1516e.ObjectInstanceHandle;
 import hla.rti1516e.exceptions.FederateInternalError;
 
 public class ProvideUpdateCallbackHandler extends LRC1516eCallbackHandler
@@ -52,8 +54,10 @@ public class ProvideUpdateCallbackHandler extends LRC1516eCallbackHandler
 	public void callback( MessageContext context ) throws FederateInternalError
 	{
 		RequestObjectUpdate request = context.getRequest( RequestObjectUpdate.class, this );
-		int objectHandle = request.getObjectId();
+		ObjectInstanceHandle objectHandle = new HLA1516eHandle( request.getObjectId() );
 		Set<Integer> attributes = request.getAttributes();
+		AttributeHandleSet ahs = new HLA1516eAttributeHandleSet( attributes );
+		byte[] tag = request.getTag();
 
 		if( logger.isTraceEnabled() )
 		{
@@ -62,9 +66,15 @@ public class ProvideUpdateCallbackHandler extends LRC1516eCallbackHandler
 		}
 		
 		// do the callback
-		fedamb().provideAttributeValueUpdate( new HLA1516eHandle(objectHandle),
-		                                      new HLA1516eAttributeHandleSet(attributes),
-		                                      request.getTag() );
+		fedamb().provideAttributeValueUpdate( objectHandle,
+		                                      ahs,
+		                                      tag );
+		helper.reportServiceInvocation( "provideAttributeValueUpdate", 
+		                                true, 
+		                                null, 
+		                                objectHandle,
+		                                ahs,
+		                                tag );
 
 		context.success();
 		

--- a/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/SupplementalInfo.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/SupplementalInfo.java
@@ -94,6 +94,12 @@ public class SupplementalInfo implements FederateAmbassador.SupplementalReceiveI
 		return this.sentRegions == null;
 	}
 
+	@Override
+	public String toString()
+	{
+		return "ProducingFederate="+producingFederate.toString();
+	}
+	
 	//----------------------------------------------------------
 	//                     STATIC METHODS
 	//----------------------------------------------------------

--- a/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/SyncAnnounceCallbackHandler.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/SyncAnnounceCallbackHandler.java
@@ -61,9 +61,12 @@ public class SyncAnnounceCallbackHandler extends LRC1516eCallbackHandler
 		}
 
 		// We're either in the set, or there is no set (federtaion wide callback)
+		String label = announcement.getLabel();
+		byte[] tag = announcement.getTag();
 		logger.trace( "CALLBACK announceSynchronizationPoint(label="+announcement.getLabel()+")" );
 		fedamb().announceSynchronizationPoint( announcement.getLabel(), announcement.getTag() );
-
+		
+		helper.reportServiceInvocation( "announceSynchronizationPoint", true, null, label, tag );
 		context.success();
 		
 		logger.trace( "         announceSynchronizationPoint() callback complete" );

--- a/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/SyncRegisterResultCallbackHandler.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/SyncRegisterResultCallbackHandler.java
@@ -55,6 +55,10 @@ public class SyncRegisterResultCallbackHandler extends LRC1516eCallbackHandler
 		{
 			logger.trace( "CALLBACK synchronizationPointRegistrationSucceeded(label="+label+")" );
 			fedamb().synchronizationPointRegistrationSucceeded( label );
+			helper.reportServiceInvocation( "synchronizationPointRegistrationSucceeded", 
+			                                true, 
+			                                null, 
+			                                label );
 			logger.trace( "         synchronizationPointRegistrationSucceeded() callback complete" );
 			
 			// deliver the announcement for the local federate as well
@@ -69,6 +73,11 @@ public class SyncRegisterResultCallbackHandler extends LRC1516eCallbackHandler
 			logger.trace( "CALLBACK synchronizationPointRegistrationFailed(label="+label+")" );
 			fedamb().synchronizationPointRegistrationFailed( label,
 			         SynchronizationPointFailureReason.SYNCHRONIZATION_POINT_LABEL_NOT_UNIQUE );
+			helper.reportServiceInvocation( "synchronizationPointRegistrationFailed", 
+			                                true, 
+			                                null, 
+			                                label,
+			                                SynchronizationPointFailureReason.SYNCHRONIZATION_POINT_LABEL_NOT_UNIQUE );
 			logger.trace( "         synchronizationPointRegistrationFailed() callback complete" );
 		}
 		

--- a/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/TimeConstrainedEnabledCallbackHandler.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/TimeConstrainedEnabledCallbackHandler.java
@@ -20,6 +20,7 @@ import org.portico.impl.hla1516e.types.time.DoubleTime;
 import org.portico.lrc.compat.JConfigurationException;
 import org.portico2.common.messaging.MessageContext;
 
+import hla.rti1516e.LogicalTime;
 import hla.rti1516e.exceptions.FederateInternalError;
 
 public class TimeConstrainedEnabledCallbackHandler extends LRC1516eCallbackHandler
@@ -48,9 +49,10 @@ public class TimeConstrainedEnabledCallbackHandler extends LRC1516eCallbackHandl
 	@Override
 	public void callback( MessageContext context ) throws FederateInternalError
 	{
-		DoubleTime currentTime = new DoubleTime( lrcState.getCurrentTime() );
+		LogicalTime<?,?> currentTime = new DoubleTime( lrcState.getCurrentTime() );
 		logger.trace( "CALLBACK timeConstrainedEnabled(time="+currentTime+")" );
 		fedamb().timeConstrainedEnabled( currentTime );
+		helper.reportServiceInvocation( "timeConstrainedEnabled", true, null, currentTime );
 		logger.trace( "         timeConstrainedEnabled() callback complete" );
 		context.success();
 	}

--- a/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/TimeRegulationEnabledCallbackHandler.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/TimeRegulationEnabledCallbackHandler.java
@@ -20,6 +20,7 @@ import org.portico.impl.hla1516e.types.time.DoubleTime;
 import org.portico.lrc.compat.JConfigurationException;
 import org.portico2.common.messaging.MessageContext;
 
+import hla.rti1516e.LogicalTime;
 import hla.rti1516e.exceptions.FederateInternalError;
 
 public class TimeRegulationEnabledCallbackHandler extends LRC1516eCallbackHandler
@@ -48,9 +49,10 @@ public class TimeRegulationEnabledCallbackHandler extends LRC1516eCallbackHandle
 	@Override
 	public void callback( MessageContext context ) throws FederateInternalError
 	{
-		DoubleTime currentTime = new DoubleTime( lrcState.getCurrentTime() );
+		LogicalTime<?,?> currentTime = new DoubleTime( lrcState.getCurrentTime() );
 		logger.trace( "CALLBACK timeRegulationEnabled(time="+currentTime+")" );
 		fedamb().timeRegulationEnabled( currentTime );
+		helper.reportServiceInvocation( "timeRegulationEnabled", true, null, currentTime );
 		logger.trace( "         timeRegulationEnabled() callback complete" );
 		context.success();
 	}

--- a/codebase/src/java/portico/org/portico2/common/messaging/MessageType.java
+++ b/codebase/src/java/portico/org/portico2/common/messaging/MessageType.java
@@ -114,9 +114,14 @@ public enum MessageType
 	DeleteRegion            ( (short)141 ),
 	ModifyRegion            ( (short)142 ),
 	AssociateRegion         ( (short)143 ),
-	UnassociateRegion       ( (short)144 );
+	UnassociateRegion       ( (short)144 ),
 
-	// Reserved for future use (150-253)
+	
+	// Management Object Model (150-159)
+	SetServiceReporting     ( (short)150 ),
+	SetExceptionReporting   ( (short)151 );
+	
+	// Reserved for future use (160-253)
 	
 	// RESERVED (UPDATE/SEND - 254, 255 - Above)
 	

--- a/codebase/src/java/portico/org/portico2/common/services/mom/msg/SetExceptionReporting.java
+++ b/codebase/src/java/portico/org/portico2/common/services/mom/msg/SetExceptionReporting.java
@@ -1,0 +1,116 @@
+/*
+ *   Copyright 2006 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.common.services.mom.msg;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+import org.portico.utils.messaging.PorticoMessage;
+import org.portico2.common.messaging.MessageType;
+import org.portico2.lrc.LRC;
+import org.portico2.lrc.LRCState;
+
+/**
+ * This message is a command from the RTI that indicates the destination federate should enable/disable
+ * its MOM Exception reporting.
+ * <p/>
+ * Exception reporting is performed on the LRC side as all parameter and return type information is 
+ * available. Additionally it is much easier to catch exceptions on the LRC side.
+ * <p/>
+ * If MOM Exception reporting is enabled, then service invocation exceptions will be reported to the
+ * federation through the <code>HLAmanager.HLAfederate.HLAreport.HLAreportException</code> interaction.
+ * 
+ * @see LRCState#isExceptionReporting()
+ * @see LRC#reportServiceInvocation(String, boolean, Object, String, Object...)
+ */
+public class SetExceptionReporting extends PorticoMessage implements Externalizable
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+	private static final long serialVersionUID = 3112252018924L;
+	
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private boolean reporting;
+	
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public SetExceptionReporting()
+	{
+		super();
+	}
+	
+	public SetExceptionReporting( boolean reporting )
+	{
+		this();
+		this.reporting = reporting;
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	public MessageType getType()
+	{
+		return MessageType.SetExceptionReporting;
+	}
+	
+	public boolean isExceptionReporting()
+	{
+		return this.reporting;
+	}
+	
+	public void setExceptionReporting( boolean reporting )
+	{
+		this.reporting = reporting;
+	}
+	
+	/**
+	 * Returns <code>false</code>
+	 */
+	@Override
+	public boolean isSpecDefinedMessage()
+	{
+		return false;
+	}
+
+	/////////////////////////////////////////////////////////////
+	/////////////////// Serialization Methods ///////////////////
+	/////////////////////////////////////////////////////////////
+	@Override
+	public void readExternal( ObjectInput input ) throws IOException, ClassNotFoundException
+	{
+		super.readExternal( input );
+		this.reporting = input.readBoolean();
+	}
+	
+	@Override
+	public void writeExternal( ObjectOutput output ) throws IOException
+	{
+		super.writeExternal( output );
+		
+		output.writeBoolean( this.reporting );
+	}
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	
+}

--- a/codebase/src/java/portico/org/portico2/common/services/mom/msg/SetServiceReporting.java
+++ b/codebase/src/java/portico/org/portico2/common/services/mom/msg/SetServiceReporting.java
@@ -1,0 +1,118 @@
+/*
+ *   Copyright 2006 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.common.services.mom.msg;
+
+import java.io.Externalizable;
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+import org.portico.utils.messaging.PorticoMessage;
+import org.portico2.common.messaging.MessageType;
+import org.portico2.lrc.LRC;
+import org.portico2.lrc.LRCState;
+
+/**
+ * This message is a command from the RTI that indicates the destination federate should enable/disable
+ * its MOM Service Invocation reporting.
+ * <p/>
+ * Service Invocation reporting is performed on the LRC side as all parameter and return type information 
+ * is available at the invocation point. Additionally it is much easier to catch exceptions on the LRC 
+ * side.
+ * <p/>
+ * If MOM Service Invocation reporting is enabled, then all of the federate's service invocations will be 
+ * reported to the federation through the 
+ * <code>HLAmanager.HLAfederate.HLAreport.HLAreportServiceInvocation</code> interaction.
+ * 
+ * @see LRCState#isServiceReporting()
+ * @see LRC#reportServiceInvocation(String, boolean, Object, String, Object...)
+ */
+public class SetServiceReporting extends PorticoMessage implements Externalizable
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+	private static final long serialVersionUID = 3112252018924L;
+	
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private boolean reporting;
+	
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public SetServiceReporting()
+	{
+		super();
+	}
+	
+	public SetServiceReporting( boolean reporting )
+	{
+		this();
+		this.reporting = reporting;
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	public MessageType getType()
+	{
+		return MessageType.SetServiceReporting;
+	}
+	
+	public boolean isServiceReporting()
+	{
+		return this.reporting;
+	}
+	
+	public void setServiceReporting( boolean reporting )
+	{
+		this.reporting = reporting;
+	}
+	
+	/**
+	 * Returns <code>false</code>
+	 */
+	@Override
+	public boolean isSpecDefinedMessage()
+	{
+		return false;
+	}
+
+	/////////////////////////////////////////////////////////////
+	/////////////////// Serialization Methods ///////////////////
+	/////////////////////////////////////////////////////////////
+	@Override
+	public void readExternal( ObjectInput input ) throws IOException, ClassNotFoundException
+	{
+		super.readExternal( input );
+		this.reporting = input.readBoolean();
+	}
+	
+	@Override
+	public void writeExternal( ObjectOutput output ) throws IOException
+	{
+		super.writeExternal( output );
+		
+		output.writeBoolean( this.reporting );
+	}
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	
+}

--- a/codebase/src/java/portico/org/portico2/lrc/LRCHandlerRegistry.java
+++ b/codebase/src/java/portico/org/portico2/lrc/LRCHandlerRegistry.java
@@ -41,6 +41,8 @@ import org.portico2.lrc.services.federation.outgoing.DestroyFederationHandler;
 import org.portico2.lrc.services.federation.outgoing.JoinFederationHandler;
 import org.portico2.lrc.services.federation.outgoing.ListFederationsHandler;
 import org.portico2.lrc.services.federation.outgoing.ResignFederationHandler;
+import org.portico2.lrc.services.mom.incoming.SetExceptionReportingHandler;
+import org.portico2.lrc.services.mom.incoming.SetServiceReportingHandler;
 import org.portico2.lrc.services.object.incoming.DiscoverObjectHandler;
 import org.portico2.lrc.services.object.incoming.ProvideObjectUpdateHandler;
 import org.portico2.lrc.services.object.incoming.ReceiveInteractionHandler;
@@ -212,6 +214,10 @@ public class LRCHandlerRegistry
 
 		in.register( MessageType.OwnershipAcquired,       new AttributesAcquiredIncomingHandler() );
 		in.register( MessageType.OwnershipAcquired,       new AttributesAcquiredCallbackHandler() );
+		
+		// MOM
+		in.register( MessageType.SetServiceReporting,     new SetServiceReportingHandler() );
+		in.register( MessageType.SetExceptionReporting,   new SetExceptionReportingHandler() );
 		
 		// Configure all the registered handlers
 		in.configure( settings );

--- a/codebase/src/java/portico/org/portico2/lrc/LRCState.java
+++ b/codebase/src/java/portico/org/portico2/lrc/LRCState.java
@@ -78,6 +78,12 @@ public class LRCState
 	// DDM state entities //
 	private RegionStore regionStore;
 	
+	// MOM Settings //
+	private boolean serviceReporting;
+	private boolean exceptionReporting;
+	private int serviceInvocationCounter;
+	
+	
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
 	//----------------------------------------------------------
@@ -495,6 +501,31 @@ public class LRCState
 	public RegionStore getRegionStore()
 	{
 		return this.regionStore;
+	}
+
+	public boolean isServiceReporting()
+	{
+		return this.serviceReporting;
+	}
+	
+	public void setServiceReporting( boolean reporting )
+	{
+		this.serviceReporting = reporting;
+	}
+	
+	public boolean isExceptionReporting()
+	{
+		return this.exceptionReporting;
+	}
+	
+	public void setExceptionReporting( boolean reporting )
+	{
+		this.exceptionReporting = reporting;
+	}
+	
+	public int getNextServiceInvocationSerial()
+	{
+		return this.serviceInvocationCounter++;
 	}
 	
 	protected boolean isQueueLogging()

--- a/codebase/src/java/portico/org/portico2/lrc/services/mom/incoming/SetExceptionReportingHandler.java
+++ b/codebase/src/java/portico/org/portico2/lrc/services/mom/incoming/SetExceptionReportingHandler.java
@@ -12,19 +12,18 @@
  *   (that goes for your lawyer as well)
  *
  */
-package org.portico.impl.hla1516e.handlers2;
+package org.portico2.lrc.services.mom.incoming;
 
 import java.util.Map;
 
-import org.portico.impl.hla1516e.types.time.DoubleTime;
 import org.portico.lrc.compat.JConfigurationException;
+import org.portico.lrc.compat.JException;
 import org.portico2.common.messaging.MessageContext;
-import org.portico2.common.services.time.msg.TimeAdvanceGrant;
+import org.portico2.common.services.mom.msg.SetExceptionReporting;
+import org.portico2.lrc.LRCMessageHandler;
+import org.portico2.lrc.LRCState;
 
-import hla.rti1516e.LogicalTime;
-import hla.rti1516e.exceptions.FederateInternalError;
-
-public class TimeAdvanceGrantCallbackHandler extends LRC1516eCallbackHandler
+public class SetExceptionReportingHandler extends LRCMessageHandler
 {
 	//----------------------------------------------------------
 	//                    STATIC VARIABLES
@@ -46,21 +45,23 @@ public class TimeAdvanceGrantCallbackHandler extends LRC1516eCallbackHandler
 	{
 		super.configure( properties );
 	}
-
+	
 	@Override
-	public void callback( MessageContext context ) throws FederateInternalError
+	public void process( MessageContext context ) throws JException
 	{
-		TimeAdvanceGrant grant = context.getRequest( TimeAdvanceGrant.class, this );
-		LogicalTime<?,?> theTime = new DoubleTime( grant.getTime() );
-		if( logger.isTraceEnabled() )
-			logger.trace( "CALLBACK timeAdvanceGrant(time="+theTime+")" );
-		fedamb().timeAdvanceGrant( theTime );
-		helper.reportServiceInvocation( "timeAdvanceGrant", true, null, theTime );
+		vetoUnlessForUs( context.getRequest() );
+		
+		SetExceptionReporting request = context.getRequest( SetExceptionReporting.class );
+		LRCState state = lrc.getState();
+		state.setExceptionReporting( request.isExceptionReporting() );
+		
 		context.success();
-
-		if( logger.isTraceEnabled() )
-			logger.trace( "         timeAdvanceGrant() callback complete" );
 	}
+
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+
 
 	//----------------------------------------------------------
 	//                     STATIC METHODS

--- a/codebase/src/java/portico/org/portico2/lrc/services/mom/incoming/SetServiceReportingHandler.java
+++ b/codebase/src/java/portico/org/portico2/lrc/services/mom/incoming/SetServiceReportingHandler.java
@@ -12,19 +12,18 @@
  *   (that goes for your lawyer as well)
  *
  */
-package org.portico.impl.hla1516e.handlers2;
+package org.portico2.lrc.services.mom.incoming;
 
 import java.util.Map;
 
-import org.portico.impl.hla1516e.types.time.DoubleTime;
 import org.portico.lrc.compat.JConfigurationException;
+import org.portico.lrc.compat.JException;
 import org.portico2.common.messaging.MessageContext;
-import org.portico2.common.services.time.msg.TimeAdvanceGrant;
+import org.portico2.common.services.mom.msg.SetServiceReporting;
+import org.portico2.lrc.LRCMessageHandler;
+import org.portico2.lrc.LRCState;
 
-import hla.rti1516e.LogicalTime;
-import hla.rti1516e.exceptions.FederateInternalError;
-
-public class TimeAdvanceGrantCallbackHandler extends LRC1516eCallbackHandler
+public class SetServiceReportingHandler extends LRCMessageHandler
 {
 	//----------------------------------------------------------
 	//                    STATIC VARIABLES
@@ -46,21 +45,23 @@ public class TimeAdvanceGrantCallbackHandler extends LRC1516eCallbackHandler
 	{
 		super.configure( properties );
 	}
-
+	
 	@Override
-	public void callback( MessageContext context ) throws FederateInternalError
+	public void process( MessageContext context ) throws JException
 	{
-		TimeAdvanceGrant grant = context.getRequest( TimeAdvanceGrant.class, this );
-		LogicalTime<?,?> theTime = new DoubleTime( grant.getTime() );
-		if( logger.isTraceEnabled() )
-			logger.trace( "CALLBACK timeAdvanceGrant(time="+theTime+")" );
-		fedamb().timeAdvanceGrant( theTime );
-		helper.reportServiceInvocation( "timeAdvanceGrant", true, null, theTime );
+		vetoUnlessForUs( context.getRequest() );
+		
+		SetServiceReporting request = context.getRequest( SetServiceReporting.class );
+		LRCState state = lrc.getState();
+		state.setServiceReporting( request.isServiceReporting() );
+		
 		context.success();
-
-		if( logger.isTraceEnabled() )
-			logger.trace( "         timeAdvanceGrant() callback complete" );
 	}
+
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+
 
 	//----------------------------------------------------------
 	//                     STATIC METHODS

--- a/codebase/src/java/portico/org/portico2/lrc/services/object/data/LOCInstance.java
+++ b/codebase/src/java/portico/org/portico2/lrc/services/object/data/LOCInstance.java
@@ -302,6 +302,11 @@ public class LOCInstance
 			return false;
 	}
 
+	@Override
+	public String toString()
+	{
+		return String.valueOf( this.handle );
+	}
 	//----------------------------------------------------------
 	//                     STATIC METHODS
 	//----------------------------------------------------------

--- a/codebase/src/java/portico/org/portico2/rti/federation/FederateMetrics.java
+++ b/codebase/src/java/portico/org/portico2/rti/federation/FederateMetrics.java
@@ -44,6 +44,7 @@ public class FederateMetrics
 	private int objectsRemoved;
 	private int objectsRegistered;
 	private int objectsDiscovered;
+	private int serviceInvocations;
 
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
@@ -59,6 +60,7 @@ public class FederateMetrics
 		this.objectsRemoved = 0;
 		this.objectsRegistered = 0;
 		this.objectsDiscovered = 0;
+		this.serviceInvocations = 0;
 	}
 
 	//----------------------------------------------------------
@@ -141,6 +143,11 @@ public class FederateMetrics
 	public void objectDiscovered()
 	{
 		++this.objectsDiscovered;
+	}
+	
+	public int serviceInvoked()
+	{
+		return ++this.serviceInvocations;
 	}
 	
 	////////////////////////////////////////////////////////////////////////////////////////

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomException.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomException.java
@@ -12,19 +12,17 @@
  *   (that goes for your lawyer as well)
  *
  */
-package org.portico.impl.hla1516e.handlers2;
+package org.portico2.rti.services.mom.data;
 
-import java.util.Map;
+import org.portico2.common.services.object.msg.SendInteraction;
+import org.portico2.rti.services.mom.incoming.MomSendInteractionHandler;
 
-import org.portico.impl.hla1516e.types.time.DoubleTime;
-import org.portico.lrc.compat.JConfigurationException;
-import org.portico2.common.messaging.MessageContext;
-import org.portico2.common.services.time.msg.TimeAdvanceGrant;
-
-import hla.rti1516e.LogicalTime;
-import hla.rti1516e.exceptions.FederateInternalError;
-
-public class TimeAdvanceGrantCallbackHandler extends LRC1516eCallbackHandler
+/**
+ * Internal exception type. Indicates that an error occurred during the processing of a MOM request
+ * interaction. This exception will be reported back to the federate as a HLAreportMOMexception via
+ * the {@link MomSendInteractionHandler#reportMomException(SendInteraction, MomException)} method.
+ */
+public class MomException extends Exception
 {
 	//----------------------------------------------------------
 	//                    STATIC VARIABLES
@@ -33,35 +31,35 @@ public class TimeAdvanceGrantCallbackHandler extends LRC1516eCallbackHandler
 	//----------------------------------------------------------
 	//                   INSTANCE VARIABLES
 	//----------------------------------------------------------
-
+	private boolean parameterError;
+	
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
 	//----------------------------------------------------------
-
+	public MomException( String message, boolean parameterError )
+	{
+		super( message );
+		this.parameterError = parameterError;
+	}
+	
+	public MomException( String message, boolean parameterError, Throwable cause )
+	{
+		super( message, cause );
+		this.parameterError = parameterError;
+	}
+	
 	//----------------------------------------------------------
 	//                    INSTANCE METHODS
 	//----------------------------------------------------------
-	@Override
-	public void configure( Map<String,Object> properties ) throws JConfigurationException
+
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+	public boolean isParameterError()
 	{
-		super.configure( properties );
+		return this.parameterError;
 	}
-
-	@Override
-	public void callback( MessageContext context ) throws FederateInternalError
-	{
-		TimeAdvanceGrant grant = context.getRequest( TimeAdvanceGrant.class, this );
-		LogicalTime<?,?> theTime = new DoubleTime( grant.getTime() );
-		if( logger.isTraceEnabled() )
-			logger.trace( "CALLBACK timeAdvanceGrant(time="+theTime+")" );
-		fedamb().timeAdvanceGrant( theTime );
-		helper.reportServiceInvocation( "timeAdvanceGrant", true, null, theTime );
-		context.success();
-
-		if( logger.isTraceEnabled() )
-			logger.trace( "         timeAdvanceGrant() callback complete" );
-	}
-
+	
 	//----------------------------------------------------------
 	//                     STATIC METHODS
 	//----------------------------------------------------------

--- a/codebase/src/java/portico/org/portico2/rti/services/pubsub/incoming/PublishInteractionClassHandler.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/pubsub/incoming/PublishInteractionClassHandler.java
@@ -68,7 +68,7 @@ public class PublishInteractionClassHandler extends RTIMessageHandler
 			             federateName(federateHandle),
 			             icMoniker(classHandle) );
 		}
-
+		
 		context.success();
 	}
 

--- a/codebase/src/java/portico/org/portico2/rti/services/pubsub/incoming/PublishObjectClassHandler.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/pubsub/incoming/PublishObjectClassHandler.java
@@ -86,7 +86,7 @@ public class PublishObjectClassHandler extends RTIMessageHandler
 			             ocMoniker(classHandle),
 			             acMoniker(attributes) );
 		}
-
+		
 		context.success();
 	}
 

--- a/codebase/src/java/portico/org/portico2/rti/services/pubsub/incoming/UnpublishObjectClassHandler.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/pubsub/incoming/UnpublishObjectClassHandler.java
@@ -74,7 +74,7 @@ public class UnpublishObjectClassHandler extends RTIMessageHandler
 		releaseAttributes( federateHandle, classHandle );
 		
 		context.success();
-
+		
 		if( logger.isInfoEnabled() )
 		{
 			logger.info( "SUCCESS Federate [%s] unpublished  [%s] with attributes %s",

--- a/codebase/src/java/portico/org/portico2/rti/services/sync/incoming/RegisterSyncPointHandler.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/sync/incoming/RegisterSyncPointHandler.java
@@ -84,8 +84,9 @@ public class RegisterSyncPointHandler extends RTIMessageHandler
 		AnnounceSyncPoint announcement = new AnnounceSyncPoint( point );
 		super.queueManycast( announcement, syncset );
 		
-		// Set the respone to successful and return
+		// Set the response to successful and return
 		context.success();
+		
 		if( logger.isInfoEnabled() )
 			logger.info( "SUCCESS Registered sync point ["+label+"] by ["+moniker(source)+"]" );
 	}


### PR DESCRIPTION
This PR represents work done to statisfy Portico feature request #237 

- Added framework for Service Invocation reporting
  * RTI now intercepts `HLAfederate.HLAadjust.HLAsetServiceReporting` interactions and sends a `SetServiceReporting` message to the corresponding Federate's LRC
  * Upon receiving the SetServiceReporting, the LRC sets an internal flag that causes it to emit a `HLAreportServiceInvocation` interaction whenever an `RtiAmbassador` or `FederateAmbassador` service is invoked.
  * Added hooks to emit the `HLAreportServiceInvocation` interaction in all supported `Rti1516eAmbassador` methods
  * Added hooks to emit the `HLAreportServiceInvocation` interaction in the corresponding callback handler classes of all `FederateAmbassador` methods
  * Currently the Service Reporting switch can only be enabled via the `HLAsetServiceReporting` interaction. The FDD switches settings are ignored
- Support for Exception reporting
  * Can be enabled per-federate through the
    `HLAfederate.HLAadjust.HLAsetExceptionReporting` interaction.
  * Uses the same framework as Service Invocation reporting
- Method hook added to `MomManager` to report `HLAreportFederateLost` to the
  federation.
  * Mechanism to trigger this method does not currently exist, so have been unable to test it properly
  * In addition to sending the `HLAreportFederateLost` interaction, the method also deletes the lost federate's MOM object.

*Note* The `HLAreportMomException` interaction was implemented in the previous PR #270 