### PR TITLE
Added MOM interaction unit tests and fixed resulting bugs

### DIFF
--- a/codebase/src/java/portico/org/portico/lrc/PorticoConstants.java
+++ b/codebase/src/java/portico/org/portico/lrc/PorticoConstants.java
@@ -85,10 +85,6 @@ public class PorticoConstants
 	/** The maximum number of regions a federate is allowed to register. This value is calculated
 	    as {@link Integer#MAX_VALUE} / {@link #MAX_FEDERATES} */
 	public static final int MAX_REGIONS = Integer.MAX_VALUE / MAX_FEDERATES;
-	
-	/** The handle given to the MOM object instances registered in federations to represent the
-	    federation itself. */
-	public static final int MOM_FEDERATION_OBJECT_HANDLE = 0;
 
 	///////////////////////////////////////////////
 	//////////// System Property Names ////////////

--- a/codebase/src/java/portico/org/portico/lrc/services/object/handlers/outgoing/RequestObjectUpdateHandler.java
+++ b/codebase/src/java/portico/org/portico/lrc/services/object/handlers/outgoing/RequestObjectUpdateHandler.java
@@ -18,11 +18,12 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.portico.impl.HLAVersion;
 import org.portico.lrc.LRCMessageHandler;
-import org.portico.lrc.PorticoConstants;
 import org.portico.lrc.compat.JAttributeNotDefined;
 import org.portico.lrc.compat.JObjectNotKnown;
 import org.portico.lrc.model.ACInstance;
+import org.portico.lrc.model.Mom;
 import org.portico.lrc.model.OCInstance;
 import org.portico.utils.messaging.MessageContext;
 import org.portico.utils.messaging.MessageHandler;
@@ -42,6 +43,7 @@ public class RequestObjectUpdateHandler extends LRCMessageHandler
 	//----------------------------------------------------------
 	//                   INSTANCE VARIABLES
 	//----------------------------------------------------------
+	private int momFederationHandle;
 
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
@@ -53,6 +55,7 @@ public class RequestObjectUpdateHandler extends LRCMessageHandler
 	public void initialize( Map<String,Object> properties )
 	{
 		super.initialize( properties );
+		this.momFederationHandle = Mom.getMomObjectClassHandle( HLAVersion.HLA13, "Manager.Federation" );
 	}
 	
 	public void process( MessageContext context ) throws Exception
@@ -99,7 +102,7 @@ public class RequestObjectUpdateHandler extends LRCMessageHandler
 		request.setAttributes( nonOwnedAttributes );
 		
 		// if this is for the MOM federation object, just handle it locally
-		if( objectHandle == PorticoConstants.MOM_FEDERATION_OBJECT_HANDLE )
+		if( objectHandle == this.momFederationHandle )
 		{
 			respondToMomFederationUpdateRequest( request.getAttributes() );
 		}

--- a/codebase/src/java/portico/org/portico2/lrc/services/mom/incoming/SetServiceReportingHandler.java
+++ b/codebase/src/java/portico/org/portico2/lrc/services/mom/incoming/SetServiceReportingHandler.java
@@ -54,6 +54,8 @@ public class SetServiceReportingHandler extends LRCMessageHandler
 		SetServiceReporting request = context.getRequest( SetServiceReporting.class );
 		LRCState state = lrc.getState();
 		state.setServiceReporting( request.isServiceReporting() );
+		logger.debug( "Service invocation reporting has been " + 
+		              (request.isServiceReporting() ? "ENABLED" : "DISABLED") );
 		
 		context.success();
 	}

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomEncodingHelpers.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomEncodingHelpers.java
@@ -225,6 +225,9 @@ public class MomEncodingHelpers
 
 	public byte[] encodeHandle( Object data )
 	{
+		if( data == null )
+			return new byte[0];
+		
 		if( data instanceof Number )
 		{
 			HLA1516eHandle handle = new HLA1516eHandle( ((Number)data).intValue() );
@@ -264,6 +267,9 @@ public class MomEncodingHelpers
 	
 	public byte[] encodeHandleList( Object data )
 	{
+		if( data == null )
+			data = new int[0];
+		
 		if( data instanceof Collection<?> )
 		{
 			@SuppressWarnings("unchecked")

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomManager.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomManager.java
@@ -18,6 +18,7 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.logging.log4j.Logger;
@@ -198,15 +199,19 @@ public class MomManager implements SaveRestoreTarget
 		OCMetadata federateMetadata = instance.getRegisteredType();
 		Map<Integer,OCMetadata> subscriptions =
 		    interests.getAllSubscribersWithTypes( federateMetadata );
-
-		Set<Integer> subscribers = subscriptions.keySet();
-		for( int subscriber : subscribers )
-			this.objectDiscovered( subscriber, instance );
+		
+		for( Entry<Integer,OCMetadata> subscriberEntry : subscriptions.entrySet() )
+		{
+			int subscriberHandle = subscriberEntry.getKey();
+			OCMetadata subscriberType = subscriberEntry.getValue();
+			instance.discover( subscriberHandle, subscriberType );
+			this.objectDiscovered( subscriberHandle, instance );
+		}
 
 		if( subscriptions.size() > 0 )
 		{
 			DiscoverObject discover = new DiscoverObject( instance );
-			this.queueManycast( discover, subscribers );
+			this.queueManycast( discover, subscriptions.keySet() );
 		}
 	}
 

--- a/codebase/src/java/test/hlaunit/hla13/mom/MomFederationTest.java
+++ b/codebase/src/java/test/hlaunit/hla13/mom/MomFederationTest.java
@@ -20,7 +20,8 @@ import java.util.HashMap;
 import hla.rti.AttributeHandleSet;
 import hla.rti.jlc.EncodingHelpers;
 
-import org.portico.lrc.PorticoConstants;
+import org.portico.impl.HLAVersion;
+import org.portico.lrc.model.Mom;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterClass;
@@ -209,7 +210,7 @@ public class MomFederationTest extends Abstract13Test
 
 		// wait for a discovery of an instance //
 		// need a better way than to assume specific info about handles
-		int objectHandle = PorticoConstants.MOM_FEDERATION_OBJECT_HANDLE;
+		int objectHandle = Mom.getMomObjectClassHandle( HLAVersion.HLA13, "Manager.Federation" );
 		defaultFederate.fedamb.waitForDiscovery( objectHandle );
 		
 		// ask for the MOM to provide an update //

--- a/codebase/src/java/test/hlaunit/hla13/ownership/QueryOwnershipTest.java
+++ b/codebase/src/java/test/hlaunit/hla13/ownership/QueryOwnershipTest.java
@@ -22,7 +22,9 @@ import hla.rti.SaveInProgress;
 import hlaunit.hla13.common.Abstract13Test;
 import hlaunit.hla13.common.Test13Federate;
 
+import org.portico.impl.HLAVersion;
 import org.portico.lrc.PorticoConstants;
+import org.portico.lrc.model.Mom;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
@@ -43,6 +45,7 @@ public class QueryOwnershipTest extends Abstract13Test
 	private Test13Federate secondFederate;
 	private int aaHandle, abHandle, acHandle, baHandle;
 	private int theObject;
+	private int momFederationHandle;
 
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
@@ -55,7 +58,7 @@ public class QueryOwnershipTest extends Abstract13Test
 	public void beforeClass()
 	{
 		super.beforeClass();
-		
+		this.momFederationHandle = Mom.getMomObjectClassHandle( HLAVersion.HLA13, "Manager.Federation" );
 		this.secondFederate = new Test13Federate( "secondFederate", this );
 	}
 	
@@ -83,9 +86,9 @@ public class QueryOwnershipTest extends Abstract13Test
 		secondFederate.fedamb.waitForDiscovery( this.theObject );
 		
 		defaultFederate.quickSubscribe( "ObjectRoot.Manager.Federation", "FederationName" );
-		defaultFederate.fedamb.waitForDiscovery( PorticoConstants.MOM_FEDERATION_OBJECT_HANDLE );
+		defaultFederate.fedamb.waitForDiscovery( this.momFederationHandle );
 		secondFederate.quickSubscribe( "ObjectRoot.Manager.Federation", "FederationName" );
-		secondFederate.fedamb.waitForDiscovery( PorticoConstants.MOM_FEDERATION_OBJECT_HANDLE );
+		secondFederate.fedamb.waitForDiscovery( this.momFederationHandle );
 		secondFederate.fedamb.waitForDiscovery( theObject );
 	}
 
@@ -163,10 +166,9 @@ public class QueryOwnershipTest extends Abstract13Test
 		                     secondFederate.federateHandle );
 
 		// check the MOM object
-		int mom = PorticoConstants.MOM_FEDERATION_OBJECT_HANDLE;
 		int federationName = defaultFederate.quickACHandle("Manager.Federation", "FederationName");
-		Assert.assertEquals( defaultFederate.quickQueryOwnership(mom,federationName), OWNER_RTI );
-		Assert.assertEquals( secondFederate.quickQueryOwnership(mom,federationName), OWNER_RTI );
+		Assert.assertEquals( defaultFederate.quickQueryOwnership(this.momFederationHandle,federationName), OWNER_RTI );
+		Assert.assertEquals( secondFederate.quickQueryOwnership(this.momFederationHandle,federationName), OWNER_RTI );
 	}
 
 	//////////////////////////////////////////////////////////

--- a/codebase/src/java/test/hlaunit/ieee1516/mom/MomFederationTest.java
+++ b/codebase/src/java/test/hlaunit/ieee1516/mom/MomFederationTest.java
@@ -17,7 +17,8 @@ package hlaunit.ieee1516.mom;
 
 import java.util.HashMap;
 
-import org.portico.lrc.PorticoConstants;
+import org.portico.impl.HLAVersion;
+import org.portico.lrc.model.Mom;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterClass;
@@ -191,7 +192,7 @@ public class MomFederationTest extends Abstract1516Test
 
 		// wait for a discovery of an instance //
 		// need a better way than to assume specific info about handles
-		int objectHandle = PorticoConstants.MOM_FEDERATION_OBJECT_HANDLE;
+		int objectHandle = Mom.getMomObjectClassHandle( HLAVersion.IEEE1516, "HLAmanager.HLAfederation" );
 		defaultFederate.fedamb.waitForDiscovery( objectHandle );
 		
 		// ask for the MOM to provide an update //

--- a/codebase/src/java/test/hlaunit/ieee1516e/common/Abstract1516eTest.java
+++ b/codebase/src/java/test/hlaunit/ieee1516e/common/Abstract1516eTest.java
@@ -14,6 +14,8 @@
  */
 package hlaunit.ieee1516e.common;
 
+import java.util.Properties;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.portico.impl.hla1516e.types.HLA1516eHandle;
@@ -86,7 +88,9 @@ public abstract class Abstract1516eTest
 	protected void commonBeforeClass()
 	{
 		// Create the RTI
-		this.rti = new RTI( RID.loadRid() );
+		Properties overrides = new Properties();
+		//overrides.put( "portico.loglevel", "TRACE" );
+		this.rti = new RTI( RID.loadRid(overrides) );
 		
 		// Create the default federate
 		this.defaultFederate = new TestFederate( "defaultFederate", this );

--- a/codebase/src/java/test/hlaunit/ieee1516e/common/TestFederateAmbassador.java
+++ b/codebase/src/java/test/hlaunit/ieee1516e/common/TestFederateAmbassador.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.Vector;
+import java.util.function.Function;
 
 import org.portico.impl.hla1516e.types.HLA1516eAttributeHandleSet;
 import org.testng.Assert;
@@ -412,6 +413,39 @@ public class TestFederateAmbassador extends NullFederateAmbassador
 			}
 			
 			waitForEvent();
+		}
+	}
+	
+	public int waitForClassDiscovery( int classHandle )
+	{
+		Function<Integer,TestObject> getFirst = (c)->{
+			for( TestObject o : this.discovered )
+			{
+				if( o.getClassHandle() == c )
+					return o;
+			}
+			return null;
+		};
+		TestObject o = getFirst.apply( classHandle );
+		if( o != null )
+			return o.getHandle();
+		
+		// we haven't discovered this instance yet, wait for it //
+		long finishTime = getTimeout();
+		while( o == null && finishTime > System.currentTimeMillis() )
+		{
+			waitForEvent();
+			o = getFirst.apply( classHandle );
+		}
+		
+		if( o != null )
+		{
+			return o.getHandle();
+		}
+		else
+		{
+			throw new TimeoutException( "Timeout waiting for discovery of instance with class handle [" +
+			                            classHandle + "]" );
 		}
 	}
 	

--- a/codebase/src/java/test/hlaunit/ieee1516e/common/TestInteraction.java
+++ b/codebase/src/java/test/hlaunit/ieee1516e/common/TestInteraction.java
@@ -15,8 +15,18 @@
 package hlaunit.ieee1516e.common;
 
 import java.util.HashMap;
+import java.util.Map.Entry;
 
 import hla.rti1516e.ParameterHandleValueMap;
+import hla.rti1516e.RTIambassador;
+import hla.rti1516e.exceptions.FederateNotExecutionMember;
+import hla.rti1516e.exceptions.InteractionParameterNotDefined;
+import hla.rti1516e.exceptions.InvalidInteractionClassHandle;
+import hla.rti1516e.exceptions.InvalidParameterHandle;
+import hla.rti1516e.exceptions.NotConnected;
+import hla.rti1516e.exceptions.RTIinternalError;
+
+import org.portico.impl.hla1516e.types.HLA1516eHandle;
 import org.portico.impl.hla1516e.types.HLA1516eParameterHandleValueMap;
 
 /**
@@ -81,6 +91,26 @@ public class TestInteraction
     {
     	return parameters;
     }
+	
+	public HashMap<String,byte[]> getParametersNamed( RTIambassador rtiamb )
+		throws RTIinternalError, 
+		       NotConnected, 
+		       FederateNotExecutionMember, 
+		       InvalidInteractionClassHandle,
+		       InvalidParameterHandle,
+		       InteractionParameterNotDefined
+	{
+		HashMap<String,byte[]> namedMap = new HashMap<>();
+		HLA1516eHandle icHandle = new HLA1516eHandle( classHandle );
+		for( Entry<Integer,byte[]> entry : this.parameters.entrySet() )
+		{
+			HLA1516eHandle pHandle = new HLA1516eHandle( entry.getKey() );
+			String pName = rtiamb.getParameterName( icHandle, pHandle );
+			namedMap.put( pName, entry.getValue() );
+		}
+		
+		return namedMap;
+	}
 	
 	public byte[] getParameterValue( int handle )
 	{

--- a/codebase/src/java/test/hlaunit/ieee1516e/mom/MomExceptionReportingTest.java
+++ b/codebase/src/java/test/hlaunit/ieee1516e/mom/MomExceptionReportingTest.java
@@ -1,0 +1,164 @@
+/*
+ *   Copyright 2016 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package hlaunit.ieee1516e.mom;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.portico.impl.hla1516e.types.HLA1516eHandle;
+import org.portico.impl.hla1516e.types.encoding.HLA1516eBoolean;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import hla.rti1516e.FederateHandle;
+import hla.rti1516e.RTIambassador;
+import hla.rti1516e.RtiFactoryFactory;
+import hla.rti1516e.encoding.ByteWrapper;
+import hla.rti1516e.encoding.DataElementFactory;
+import hla.rti1516e.encoding.EncoderFactory;
+import hla.rti1516e.encoding.HLAunicodeString;
+import hla.rti1516e.exceptions.NameNotFound;
+import hlaunit.ieee1516e.common.Abstract1516eTest;
+import hlaunit.ieee1516e.common.TestFederate;
+import hlaunit.ieee1516e.common.TestInteraction;
+
+@Test(sequential=true, groups={"MomExceptionReportingTest","mom"})
+public class MomExceptionReportingTest extends Abstract1516eTest
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private TestFederate secondFederate;
+	private EncoderFactory encoders;
+	
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	@BeforeClass(alwaysRun=true)
+	public void beforeClass()
+	{
+		super.beforeClass();
+		
+		try
+		{
+			this.encoders = RtiFactoryFactory.getRtiFactory().getEncoderFactory();
+		}
+		catch( Exception e )
+		{
+			Assert.fail( "Could not create encoder factory " + e.getMessage(), e );
+		}
+	}
+	
+	@BeforeMethod(alwaysRun=true)
+	public void beforeMethod()
+	{
+		this.secondFederate = new TestFederate( "secondFederate", this );
+		this.secondFederate.quickConnectWithImmediateCallbacks();
+		
+		defaultFederate.quickCreate();
+		defaultFederate.quickJoin();
+		secondFederate.quickJoin();
+	}
+	
+	@AfterMethod(alwaysRun=true)
+	public void afterMethod()
+	{
+		secondFederate.quickResign();
+		defaultFederate.quickResign();
+		defaultFederate.quickDestroy();
+	}
+	
+	@Override
+	@AfterClass(alwaysRun=true)
+	public void afterClass()
+	{
+		super.afterClass();
+	}
+	
+	//////////////////////////////////////////////////////////////////////////////////////////
+	////////////////////////////////////// Test Methods //////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////
+
+	//////////////////////////////////////////
+	// TEST: testEnableExceptionReporting() //
+	//////////////////////////////////////////
+	@Test(enabled=true)
+	public void testEnableExceptionReporting() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederate.HLAadjust.HLAsetExceptionReporting" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportException" );
+		
+		int secondHandle = secondFederate.federateHandle;
+		Map<String,byte[]> params = new HashMap<>();
+		ByteWrapper handleWrapper = new ByteWrapper( HLA1516eHandle.EncodedLength );
+		new HLA1516eHandle( secondHandle ).encode( handleWrapper );
+		params.put( "HLAfederate", handleWrapper.array() );
+		params.put( "HLAreportingState", new HLA1516eBoolean(true).toByteArray() );
+		defaultFederate.quickSend( "HLAmanager.HLAfederate.HLAadjust.HLAsetExceptionReporting", 
+		                           params, 
+		                           null );
+		
+		// Sleep for a bit to let the switch turn on
+		Thread.sleep( 100 );
+		RTIambassador rtiamb2 = secondFederate.getRtiAmb();
+		
+		try
+		{
+			secondFederate.rtiamb.getObjectClassHandle( "BogusClass" );
+		}
+		catch( NameNotFound nnf )
+		{
+			//
+		}
+		
+		TestInteraction received =
+		    defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederate.HLAreport.HLAreportException" );
+		Map<String,byte[]> paramMap = received.getParametersNamed( defaultFederate.rtiamb );
+
+		FederateHandle federateHandle = 
+			defaultFederate.rtiamb.getFederateHandleFactory().decode( paramMap.get("HLAfederate"), 0 );
+		Assert.assertEquals( federateHandle, new HLA1516eHandle(secondHandle) );
+		
+		HLAunicodeString service = encoders.createHLAunicodeString();
+		service.decode( paramMap.get("HLAservice") );
+		
+		Assert.assertEquals( service.getValue(), "getObjectClassHandle" );
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	private class UnicodeStringFactory implements DataElementFactory<HLAunicodeString>
+	{
+		@Override
+		public HLAunicodeString createElement( int index )
+		{
+			return encoders.createHLAunicodeString();
+		}
+	}
+}

--- a/codebase/src/java/test/hlaunit/ieee1516e/mom/MomFederateLifecycleTest.java
+++ b/codebase/src/java/test/hlaunit/ieee1516e/mom/MomFederateLifecycleTest.java
@@ -52,13 +52,14 @@ public class MomFederateLifecycleTest extends Abstract1516eTest
 	public void beforeClass()
 	{
 		super.beforeClass();
-		this.secondFederate = new TestFederate( "secondFederate", this );
-		this.secondFederate.quickConnect();
 	}
 	
 	@BeforeMethod(alwaysRun=true)
 	public void beforeMethod()
 	{
+		this.secondFederate = new TestFederate( "secondFederate", this );
+		this.secondFederate.quickConnect();
+		
 		defaultFederate.quickCreate();
 		defaultFederate.quickJoin();
 		//secondFederate.quickJoin();
@@ -86,7 +87,7 @@ public class MomFederateLifecycleTest extends Abstract1516eTest
 	//////////////////////////////////////////////
 	// TEST: testMomFederateInstanceLifecycle() //
 	//////////////////////////////////////////////
-	@Test(enabled=false)
+	@Test(enabled=true)
 	public void testMomFederateInstanceLifecycle() throws Exception
 	{
 		// subscribe to the MOM information //
@@ -130,7 +131,7 @@ public class MomFederateLifecycleTest extends Abstract1516eTest
 		defaultFederate.fedamb.waitForRORemoval( two.getHandle() );
 	}
 	
-	@Test(enabled=false)
+	@Test(enabled=true)
 	public void testDisabledMom() throws Exception
 	{
 		// turn the mom off for new federations //

--- a/codebase/src/java/test/hlaunit/ieee1516e/mom/MomFederationTest.java
+++ b/codebase/src/java/test/hlaunit/ieee1516e/mom/MomFederationTest.java
@@ -16,7 +16,8 @@ package hlaunit.ieee1516e.mom;
 
 import java.util.HashMap;
 
-import org.portico.lrc.PorticoConstants;
+import org.portico.impl.HLAVersion;
+import org.portico.lrc.model.Mom;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.AfterClass;
@@ -234,7 +235,7 @@ public class MomFederationTest extends Abstract1516eTest
 	///////////////////////////////////////
 	// TEST: testMomFederationInstance() //
 	///////////////////////////////////////
-	@Test(enabled=false)
+	@Test(enabled=true)
 	public void testMomFederationInstance()
 	{
 		// subscribe to the MOM Federation class attributes //
@@ -251,11 +252,10 @@ public class MomFederationTest extends Abstract1516eTest
 		                                "HLAnextSaveName",
 		                                "HLAnextSaveTime",
 		                                "HLAautoProvide" );
-
+		
 		// wait for a discovery of an instance //
-		// need a better way than to assume specific info about handles
-		int objectHandle = PorticoConstants.MOM_FEDERATION_OBJECT_HANDLE;
-		defaultFederate.fedamb.waitForDiscovery( objectHandle );
+		int classHandle = Mom.getMomObjectClassHandle( HLAVersion.IEEE1516e, "HLAmanager.HLAfederation" );
+		int objectHandle = defaultFederate.fedamb.waitForClassDiscovery( classHandle );
 		
 		// ask for the MOM to provide an update //
 		defaultFederate.quickProvide( objectHandle, federationHandles );
@@ -276,7 +276,7 @@ public class MomFederationTest extends Abstract1516eTest
 	/////////////////////////////////////
 	// TEST: testMomFederateInstance() //
 	/////////////////////////////////////
-	@Test(enabled=false)
+	@Test(enabled=true)
 	public void testMomFederateInstance()
 	{
 		// subscirbe to the MOM Federate class attributes //

--- a/codebase/src/java/test/hlaunit/ieee1516e/mom/MomObjectModelTest.java
+++ b/codebase/src/java/test/hlaunit/ieee1516e/mom/MomObjectModelTest.java
@@ -94,7 +94,7 @@ public class MomObjectModelTest extends Abstract1516eTest
 	/**
 	 * Confirm that we can access MOM class and attribute handles.
 	 */
-	@Test(enabled=false)
+	@Test(enabled=true)
 	public void testHla1516eMomHandles()
 	{
 		// get the handles for each type //

--- a/codebase/src/java/test/hlaunit/ieee1516e/mom/MomRequestInteractionMetricsTest.java
+++ b/codebase/src/java/test/hlaunit/ieee1516e/mom/MomRequestInteractionMetricsTest.java
@@ -1,0 +1,302 @@
+/*
+ *   Copyright 2016 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package hlaunit.ieee1516e.mom;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.portico.impl.hla1516e.types.HLA1516eHandle;
+import org.portico.utils.bithelpers.BitHelpers;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import hla.rti1516e.FederateHandle;
+import hla.rti1516e.InteractionClassHandle;
+import hla.rti1516e.InteractionClassHandleFactory;
+import hla.rti1516e.RtiFactoryFactory;
+import hla.rti1516e.encoding.EncoderFactory;
+import hla.rti1516e.encoding.HLAunicodeString;
+import hlaunit.ieee1516e.common.Abstract1516eTest;
+import hlaunit.ieee1516e.common.TestFederate;
+import hlaunit.ieee1516e.common.TestInteraction;
+
+@Test(sequential=true, groups={"MomRequestInteractionMetricsTest","mom"})
+public class MomRequestInteractionMetricsTest extends Abstract1516eTest
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private TestFederate secondFederate;
+	private EncoderFactory encoders;
+	
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	@BeforeClass(alwaysRun=true)
+	public void beforeClass()
+	{
+		super.beforeClass();
+		
+		try
+		{
+			this.encoders = RtiFactoryFactory.getRtiFactory().getEncoderFactory();
+		}
+		catch( Exception e )
+		{
+			Assert.fail( "Could not create encoder factory " + e.getMessage(), e );
+		}
+	}
+	
+	@BeforeMethod(alwaysRun=true)
+	public void beforeMethod()
+	{
+		this.secondFederate = new TestFederate( "secondFederate", this );
+		this.secondFederate.quickConnect();
+		
+		defaultFederate.quickCreate();
+		defaultFederate.quickJoin();
+		secondFederate.quickJoin();
+		
+		
+	}
+	
+	@AfterMethod(alwaysRun=true)
+	public void afterMethod()
+	{
+		secondFederate.quickResign();
+		defaultFederate.quickResign();
+		defaultFederate.quickDestroy();
+	}
+	
+	@Override
+	@AfterClass(alwaysRun=true)
+	public void afterClass()
+	{
+		super.afterClass();
+	}
+	
+	//////////////////////////////////////////////////////////////////////////////////////////
+	////////////////////////////////////// Test Methods //////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////
+
+	@Test(enabled=true)
+	public void testRequestInteractionsSent() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederate.HLArequest.HLArequestInteractionsSent" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportInteractionsSent" );
+		
+		defaultFederate.quickSubscribe( "HLAinteractionRoot.X" );
+		defaultFederate.quickSubscribe( "HLAinteractionRoot.X.Y" );
+		secondFederate.quickPublish( "HLAinteractionRoot.X" );
+		secondFederate.quickPublish( "HLAinteractionRoot.X.Y" );
+		
+		InteractionClassHandle xHandle = defaultFederate.rtiamb.getInteractionClassHandle( "HLAinteractionRoot.X" );
+		InteractionClassHandle yHandle = defaultFederate.rtiamb.getInteractionClassHandle( "HLAinteractionRoot.X.Y" );
+		
+		Map<String,byte[]> xParams = new HashMap<>();
+		xParams.put( "xa", encoders.createHLAinteger32BE(1).toByteArray() );
+		xParams.put( "xb", encoders.createHLAinteger32BE(2).toByteArray() );
+		xParams.put( "xc", encoders.createHLAinteger32BE(3).toByteArray() );
+		
+		// Send X 3 times
+		for( int i = 0 ; i < 3 ; ++i )
+		{
+			secondFederate.quickSend( "HLAinteractionRoot.X", xParams, null );
+			defaultFederate.fedamb.waitForROInteraction( "HLAinteractionRoot.X" );
+		}
+		
+		Map<String,byte[]> yParams = new HashMap<>( xParams );
+		yParams.put( "ya", encoders.createHLAinteger32BE(4).toByteArray() );
+		yParams.put( "yb", encoders.createHLAinteger32BE(5).toByteArray() );
+		yParams.put( "yc", encoders.createHLAinteger32BE(6).toByteArray() );
+		
+		// Send Y 2 times
+		for( int i = 0 ; i < 2 ; ++i )
+		{
+			secondFederate.quickSend( "HLAinteractionRoot.X.Y", yParams, null );
+			defaultFederate.fedamb.waitForROInteraction( "HLAinteractionRoot.X.Y" );
+		}
+		
+		// Request interactions sent by the second federate
+		Map<String,byte[]> requestParams = new HashMap<>();
+		FederateHandle secondHandle = new HLA1516eHandle( secondFederate.federateHandle );
+		byte[] handleBuffer = new byte[secondHandle.encodedLength()];
+		secondHandle.encode( handleBuffer, 0 );
+		requestParams.put( "HLAfederate", handleBuffer );
+		
+		defaultFederate.quickSend( "HLAmanager.HLAfederate.HLArequest.HLArequestInteractionsSent", 
+		                           requestParams, 
+		                           null );
+		TestInteraction response = 
+			defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederate.HLAreport.HLAreportInteractionsSent" );
+		
+		Map<String,byte[]> responseParams = response.getParametersNamed( defaultFederate.rtiamb );
+		
+		// HLAtransportation is unsupported at the moment, always HLAreliable
+		HLAunicodeString transportation = encoders.createHLAunicodeString();
+		transportation.decode( responseParams.get("HLAtransportation") );
+		Assert.assertEquals( transportation.getValue(), "HLAreliable" );
+		
+		byte[] interactionCounts = responseParams.get( "HLAinteractionCounts" );
+		
+		// Should be two counts (X and X.Y)
+		int offset = 0;
+		int size = BitHelpers.readIntBE( interactionCounts, offset );
+		offset += 4;
+		Assert.assertEquals( size, 2 );
+		
+		InteractionClassHandleFactory icHandleFactory = 
+			defaultFederate.rtiamb.getInteractionClassHandleFactory();
+		for( int i = 0 ; i < size ; ++i )
+		{
+			InteractionClassHandle icHandle = icHandleFactory.decode( interactionCounts, offset );
+			offset += icHandle.encodedLength();
+			
+			int count = BitHelpers.readIntBE( interactionCounts, offset );
+			offset += 4;
+			
+			if( icHandle.equals(xHandle) )
+				Assert.assertEquals( count, 3 );
+			else if( icHandle.equals(yHandle) )
+				Assert.assertEquals( count, 2 );
+			else
+				Assert.fail( "Unexpected ic handle: " + icHandle );
+		}
+	}
+	
+	@Test(enabled=true)
+	public void testRequestInteractionsReceived() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederate.HLArequest.HLArequestInteractionsReceived" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportInteractionsReceived" );
+		
+		defaultFederate.quickPublish( "HLAinteractionRoot.X" );
+		defaultFederate.quickPublish( "HLAinteractionRoot.X.Y" );
+		secondFederate.quickSubscribe( "HLAinteractionRoot.X" );
+		secondFederate.quickSubscribe( "HLAinteractionRoot.X.Y" );
+		
+		InteractionClassHandle xHandle = defaultFederate.rtiamb.getInteractionClassHandle( "HLAinteractionRoot.X" );
+		InteractionClassHandle yHandle = defaultFederate.rtiamb.getInteractionClassHandle( "HLAinteractionRoot.X.Y" );
+		
+		Map<String,byte[]> xParams = new HashMap<>();
+		xParams.put( "xa", encoders.createHLAinteger32BE(1).toByteArray() );
+		xParams.put( "xb", encoders.createHLAinteger32BE(2).toByteArray() );
+		xParams.put( "xc", encoders.createHLAinteger32BE(3).toByteArray() );
+		
+		// Send X 3 times
+		for( int i = 0 ; i < 3 ; ++i )
+		{
+			defaultFederate.quickSend( "HLAinteractionRoot.X", xParams, null );
+			secondFederate.fedamb.waitForROInteraction( "HLAinteractionRoot.X" );
+		}
+		
+		Map<String,byte[]> yParams = new HashMap<>( xParams );
+		yParams.put( "ya", encoders.createHLAinteger32BE(4).toByteArray() );
+		yParams.put( "yb", encoders.createHLAinteger32BE(5).toByteArray() );
+		yParams.put( "yc", encoders.createHLAinteger32BE(6).toByteArray() );
+		
+		// Send Y 2 times
+		for( int i = 0 ; i < 2 ; ++i )
+		{
+			defaultFederate.quickSend( "HLAinteractionRoot.X.Y", yParams, null );
+			secondFederate.fedamb.waitForROInteraction( "HLAinteractionRoot.X.Y" );
+		}
+		
+		// Request interactions received by the second federate
+		Map<String,byte[]> requestParams = new HashMap<>();
+		FederateHandle secondHandle = new HLA1516eHandle( secondFederate.federateHandle );
+		byte[] handleBuffer = new byte[secondHandle.encodedLength()];
+		secondHandle.encode( handleBuffer, 0 );
+		requestParams.put( "HLAfederate", handleBuffer );
+		
+		defaultFederate.quickSend( "HLAmanager.HLAfederate.HLArequest.HLArequestInteractionsReceived", 
+		                           requestParams, 
+		                           null );
+		TestInteraction response = 
+			defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederate.HLAreport.HLAreportInteractionsReceived" );
+		
+		Map<String,byte[]> responseParams = response.getParametersNamed( defaultFederate.rtiamb );
+		
+		// HLAtransportation is unsupported at the moment, always HLAreliable
+		HLAunicodeString transportation = encoders.createHLAunicodeString();
+		transportation.decode( responseParams.get("HLAtransportation") );
+		Assert.assertEquals( transportation.getValue(), "HLAreliable" );
+		
+		byte[] interactionCounts = responseParams.get( "HLAinteractionCounts" );
+		
+		// Should be two counts (X and X.Y)
+		int offset = 0;
+		int size = BitHelpers.readIntBE( interactionCounts, offset );
+		offset += 4;
+		Assert.assertEquals( size, 2 );
+		
+		InteractionClassHandleFactory icHandleFactory = 
+			defaultFederate.rtiamb.getInteractionClassHandleFactory();
+		for( int i = 0 ; i < size ; ++i )
+		{
+			InteractionClassHandle icHandle = icHandleFactory.decode( interactionCounts, offset );
+			offset += icHandle.encodedLength();
+			
+			int count = BitHelpers.readIntBE( interactionCounts, offset );
+			offset += 4;
+			
+			if( icHandle.equals(xHandle) )
+				Assert.assertEquals( count, 3 );
+			else if( icHandle.equals(yHandle) )
+				Assert.assertEquals( count, 2 );
+			else
+				Assert.fail( "Unexpected ic handle: " + icHandle );
+		}
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	public static void main( String[] args )
+	{
+		MomRequestInteractionMetricsTest test = new MomRequestInteractionMetricsTest();
+		test.commonBeforeClass();
+		test.beforeClass();
+		test.commonBeforeMethod();
+		test.beforeMethod();
+		
+		try
+		{
+			test.testRequestInteractionsSent();
+		}
+		catch( Exception e )
+		{
+			e.printStackTrace();
+		}
+		
+		test.afterMethod();
+		test.commonAfterMethod();
+		test.afterClass();
+		test.commonAfterClass();
+	}
+}

--- a/codebase/src/java/test/hlaunit/ieee1516e/mom/MomRequestObjectMetricsTest.java
+++ b/codebase/src/java/test/hlaunit/ieee1516e/mom/MomRequestObjectMetricsTest.java
@@ -1,0 +1,665 @@
+/*
+ *   Copyright 2016 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package hlaunit.ieee1516e.mom;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.portico.impl.hla1516e.types.HLA1516eHandle;
+import org.portico.lrc.model.ObjectModel;
+import org.portico.utils.bithelpers.BitHelpers;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import hla.rti1516e.AttributeHandle;
+import hla.rti1516e.AttributeHandleFactory;
+import hla.rti1516e.AttributeHandleValueMap;
+import hla.rti1516e.FederateHandle;
+import hla.rti1516e.FederateHandleFactory;
+import hla.rti1516e.ObjectClassHandle;
+import hla.rti1516e.ObjectClassHandleFactory;
+import hla.rti1516e.ObjectInstanceHandle;
+import hla.rti1516e.ObjectInstanceHandleFactory;
+import hla.rti1516e.RtiFactoryFactory;
+import hla.rti1516e.encoding.ByteWrapper;
+import hla.rti1516e.encoding.DataElementFactory;
+import hla.rti1516e.encoding.EncoderFactory;
+import hla.rti1516e.encoding.HLAinteger32BE;
+import hla.rti1516e.encoding.HLAunicodeString;
+import hlaunit.ieee1516e.common.Abstract1516eTest;
+import hlaunit.ieee1516e.common.TestFederate;
+import hlaunit.ieee1516e.common.TestInteraction;
+
+@Test(sequential=true, groups={"MomRequestObjectMetricsTest","mom"})
+public class MomRequestObjectMetricsTest extends Abstract1516eTest
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private TestFederate secondFederate;
+	private EncoderFactory encoders;
+	private int instanceHandle1;
+	private int instanceHandle2;
+	private int instanceHandle3;
+	private int instanceHandle4;
+	
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	@BeforeClass(alwaysRun=true)
+	public void beforeClass()
+	{
+		super.beforeClass();
+		
+		try
+		{
+			this.encoders = RtiFactoryFactory.getRtiFactory().getEncoderFactory();
+		}
+		catch( Exception e )
+		{
+			Assert.fail( "Could not create encoder factory " + e.getMessage(), e );
+		}
+	}
+	
+	@BeforeMethod(alwaysRun=true)
+	public void beforeMethod()
+	{
+		this.secondFederate = new TestFederate( "secondFederate", this );
+		this.secondFederate.quickConnect();
+		
+		defaultFederate.quickCreate();
+		defaultFederate.quickJoin();
+		secondFederate.quickJoin();
+		
+		defaultFederate.quickSubscribe( "HLAobjectRoot.A", "aa", "ab", "ac" );
+		secondFederate.quickPublish( "HLAobjectRoot.A", "aa", "ab", "ac" );
+		secondFederate.quickPublish( "HLAobjectRoot.B", "ba", "bb", "bc" );
+		
+		instanceHandle1 = secondFederate.quickRegister( "HLAobjectRoot.A", "object1" );
+		instanceHandle2 = secondFederate.quickRegister( "HLAobjectRoot.A", "object2" );
+		instanceHandle3 = secondFederate.quickRegister( "HLAobjectRoot.A", "object3" );
+		instanceHandle4 = secondFederate.quickRegister( "HLAobjectRoot.B", "object4" );
+	}
+	
+	@AfterMethod(alwaysRun=true)
+	public void afterMethod()
+	{
+		secondFederate.quickResign();
+		defaultFederate.quickResign();
+		defaultFederate.quickDestroy();
+	}
+	
+	@Override
+	@AfterClass(alwaysRun=true)
+	public void afterClass()
+	{
+		super.afterClass();
+	}
+	
+	//////////////////////////////////////////////////////////////////////////////////////////
+	////////////////////////////////////// Test Methods //////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////
+
+	////////////////////////////////////////////////////////
+	// TEST: testRequestObjectInstancesThatCanBeDeleted() //
+	////////////////////////////////////////////////////////
+	@Test(enabled=true)
+	public void testRequestObjectInstancesThatCanBeDeleted() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederate.HLArequest.HLArequestObjectInstancesThatCanBeDeleted" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportObjectInstancesThatCanBeDeleted" );
+		
+		ObjectClassHandleFactory ocHandleFactory = defaultFederate.rtiamb.getObjectClassHandleFactory();
+		FederateHandleFactory fedHandleFactory = defaultFederate.rtiamb.getFederateHandleFactory();
+		
+		ObjectClassHandle aHandle = defaultFederate.rtiamb.getObjectClassHandle( "HLAobjectRoot.A" );
+		ObjectClassHandle bHandle = defaultFederate.rtiamb.getObjectClassHandle( "HLAobjectRoot.A.B" );
+		
+		int secondHandle = secondFederate.federateHandle;
+		Map<String,byte[]> params = new HashMap<>();
+		ByteWrapper handleWrapper = new ByteWrapper( HLA1516eHandle.EncodedLength );
+		new HLA1516eHandle( secondHandle ).encode( handleWrapper );
+		params.put( "HLAfederate", handleWrapper.array() );
+		defaultFederate.quickSend( "HLAmanager.HLAfederate.HLArequest.HLArequestObjectInstancesThatCanBeDeleted", 
+		                           params, 
+		                           null );
+		
+		TestInteraction response = 
+			defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederate.HLAreport.HLAreportObjectInstancesThatCanBeDeleted" );
+		
+		Map<String,byte[]> recvParams = response.getParametersNamed( defaultFederate.rtiamb );
+		
+		// Handle should be the second federate
+		FederateHandle handle = fedHandleFactory.decode( recvParams.get("HLAfederate"), 0 );
+		Assert.assertEquals( handle, new HLA1516eHandle(secondHandle) );
+		
+		// Should be a total of 2 entries (e.g. 2 classes)
+		int offset = 0;
+		byte[] data = recvParams.get("HLAobjectInstanceCounts");
+		HLAinteger32BE count = encoders.createHLAinteger32BE();
+		count.decode( data );
+		offset += count.getEncodedLength();
+		Assert.assertEquals( count.getValue(), 2 );
+		
+		for( int i = 0 ; i < count.getValue() ; ++i )
+		{
+			ObjectClassHandle oc = ocHandleFactory.decode( data, offset );
+			offset += oc.encodedLength();
+			int instanceCount = BitHelpers.readIntBE( data, offset );
+			offset += 4;
+			
+			if( oc.equals(aHandle) )
+				Assert.assertEquals( instanceCount, 3 );
+			else if( oc.equals(bHandle) )
+				Assert.assertEquals( instanceCount, 1 );
+			else
+				Assert.fail( "Unexpected class handle in HLAobjectInstanceCounts: " + oc );
+		}
+	}
+	
+	///////////////////////////////////////////////
+	// TEST: testRequestObjectInstancesUpdated() //
+	///////////////////////////////////////////////
+	@Test(enabled=true)
+	public void testRequestObjectInstancesUpdated() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederate.HLArequest.HLArequestObjectInstancesUpdated" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportObjectInstancesUpdated" );
+		
+		ObjectClassHandleFactory ocHandleFactory = defaultFederate.rtiamb.getObjectClassHandleFactory();
+		FederateHandleFactory fedHandleFactory = defaultFederate.rtiamb.getFederateHandleFactory();
+		
+		ObjectClassHandle aHandle = defaultFederate.rtiamb.getObjectClassHandle( "HLAobjectRoot.A" );
+		ObjectClassHandle bHandle = defaultFederate.rtiamb.getObjectClassHandle( "HLAobjectRoot.A.B" );
+		
+		// Update some A instances
+		AttributeHandleValueMap ahvmpA = secondFederate.rtiamb.getAttributeHandleValueMapFactory().create( 3 );
+		ahvmpA.put( secondFederate.rtiamb.getAttributeHandle(aHandle, "aa"), new String("aa").getBytes() );
+		ahvmpA.put( secondFederate.rtiamb.getAttributeHandle(aHandle, "ab"), new String("ab").getBytes() );
+		ahvmpA.put( secondFederate.rtiamb.getAttributeHandle(aHandle, "ac"), new String("ac").getBytes() );
+		secondFederate.rtiamb.updateAttributeValues( new HLA1516eHandle(instanceHandle1), 
+		                                             ahvmpA, 
+		                                             null );
+		secondFederate.rtiamb.updateAttributeValues( new HLA1516eHandle(instanceHandle3), 
+		                                             ahvmpA, 
+		                                             null );
+		
+		// Update the B instance
+		AttributeHandleValueMap ahvmpB = secondFederate.rtiamb.getAttributeHandleValueMapFactory().create( 1 );
+		ahvmpB.put( secondFederate.rtiamb.getAttributeHandle(bHandle, "ba"), new String("ba").getBytes() );
+		ahvmpB.put( secondFederate.rtiamb.getAttributeHandle(bHandle, "bb"), new String("bb").getBytes() );
+		ahvmpB.put( secondFederate.rtiamb.getAttributeHandle(bHandle, "bc"), new String("bc").getBytes() );
+		secondFederate.rtiamb.updateAttributeValues( new HLA1516eHandle(instanceHandle4), 
+		                                             ahvmpB, 
+		                                             null );
+		
+		// And update it again!
+		secondFederate.rtiamb.updateAttributeValues( new HLA1516eHandle(instanceHandle4), 
+		                                             ahvmpB, 
+		                                             null );
+		
+		int secondHandle = secondFederate.federateHandle;
+		Map<String,byte[]> params = new HashMap<>();
+		ByteWrapper handleWrapper = new ByteWrapper( HLA1516eHandle.EncodedLength );
+		new HLA1516eHandle( secondHandle ).encode( handleWrapper );
+		params.put( "HLAfederate", handleWrapper.array() );
+		defaultFederate.quickSend( "HLAmanager.HLAfederate.HLArequest.HLArequestObjectInstancesUpdated", 
+		                           params, 
+		                           null );
+		
+		TestInteraction response = 
+			defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederate.HLAreport.HLAreportObjectInstancesUpdated" );
+		
+		Map<String,byte[]> recvParams = response.getParametersNamed( defaultFederate.rtiamb );
+		
+		// Handle should be the second federate
+		FederateHandle handle = fedHandleFactory.decode( recvParams.get("HLAfederate"), 0 );
+		Assert.assertEquals( handle, new HLA1516eHandle(secondHandle) );
+		
+		// Should be a total of 2 entries (e.g. 2 classes)
+		int offset = 0;
+		byte[] data = recvParams.get("HLAobjectInstanceCounts");
+		HLAinteger32BE count = encoders.createHLAinteger32BE();
+		count.decode( data );
+		offset += count.getEncodedLength();
+		Assert.assertEquals( count.getValue(), 2 );
+		
+		for( int i = 0 ; i < count.getValue() ; ++i )
+		{
+			ObjectClassHandle oc = ocHandleFactory.decode( data, offset );
+			offset += oc.encodedLength();
+			int instanceCount = BitHelpers.readIntBE( data, offset );
+			offset += 4;
+			
+			if( oc.equals(aHandle) )
+				Assert.assertEquals( instanceCount, 2 );
+			else if( oc.equals(bHandle) )
+				Assert.assertEquals( instanceCount, 1 ); // Only 1 because the metric is "unique object instances updated" 
+			else
+				Assert.fail( "Unexpected class handle in HLAobjectInstanceCounts: " + oc );
+		}
+	}
+	
+	/////////////////////////////////////////////////
+	// TEST: testRequestObjectInstancesReflected() //
+	/////////////////////////////////////////////////
+	@Test(enabled=true)
+	public void testRequestObjectInstancesReflected() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederate.HLArequest.HLArequestObjectInstancesReflected" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportObjectInstancesReflected" );
+		
+		ObjectClassHandleFactory ocHandleFactory = defaultFederate.rtiamb.getObjectClassHandleFactory();
+		FederateHandleFactory fedHandleFactory = defaultFederate.rtiamb.getFederateHandleFactory();
+		
+		ObjectClassHandle aHandle = defaultFederate.rtiamb.getObjectClassHandle( "HLAobjectRoot.A" );
+		ObjectClassHandle bHandle = defaultFederate.rtiamb.getObjectClassHandle( "HLAobjectRoot.A.B" );
+		
+		// Update some A instances
+		AttributeHandleValueMap ahvmpA = secondFederate.rtiamb.getAttributeHandleValueMapFactory().create( 3 );
+		ahvmpA.put( secondFederate.rtiamb.getAttributeHandle(aHandle, "aa"), new String("aa").getBytes() );
+		ahvmpA.put( secondFederate.rtiamb.getAttributeHandle(aHandle, "ab"), new String("ab").getBytes() );
+		ahvmpA.put( secondFederate.rtiamb.getAttributeHandle(aHandle, "ac"), new String("ac").getBytes() );
+		secondFederate.rtiamb.updateAttributeValues( new HLA1516eHandle(instanceHandle1), 
+		                                             ahvmpA, 
+		                                             null );
+		secondFederate.rtiamb.updateAttributeValues( new HLA1516eHandle(instanceHandle3), 
+		                                             ahvmpA, 
+		                                             null );
+		
+		// Update the B instance
+		AttributeHandleValueMap ahvmpB = secondFederate.rtiamb.getAttributeHandleValueMapFactory().create( 1 );
+		ahvmpB.put( secondFederate.rtiamb.getAttributeHandle(bHandle, "ba"), new String("ba").getBytes() );
+		ahvmpB.put( secondFederate.rtiamb.getAttributeHandle(bHandle, "bb"), new String("bb").getBytes() );
+		ahvmpB.put( secondFederate.rtiamb.getAttributeHandle(bHandle, "bc"), new String("bc").getBytes() );
+		secondFederate.rtiamb.updateAttributeValues( new HLA1516eHandle(instanceHandle4), 
+		                                             ahvmpB, 
+		                                             null );
+		
+		// And update it again!
+		secondFederate.rtiamb.updateAttributeValues( new HLA1516eHandle(instanceHandle4), 
+		                                             ahvmpB, 
+		                                             null );
+		
+		int firstHandle = defaultFederate.federateHandle;
+		Map<String,byte[]> params = new HashMap<>();
+		ByteWrapper handleWrapper = new ByteWrapper( HLA1516eHandle.EncodedLength );
+		new HLA1516eHandle( firstHandle ).encode( handleWrapper );
+		params.put( "HLAfederate", handleWrapper.array() );
+		defaultFederate.quickSend( "HLAmanager.HLAfederate.HLArequest.HLArequestObjectInstancesReflected", 
+		                           params, 
+		                           null );
+		
+		TestInteraction response = 
+			defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederate.HLAreport.HLAreportObjectInstancesReflected" );
+		
+		Map<String,byte[]> recvParams = response.getParametersNamed( defaultFederate.rtiamb );
+		
+		// Handle should be the first federate
+		FederateHandle handle = fedHandleFactory.decode( recvParams.get("HLAfederate"), 0 );
+		Assert.assertEquals( handle, new HLA1516eHandle(firstHandle) );
+		
+		// Should be a total of 1 entry (e.g. defaultFederate is only subscribed to A)
+		int offset = 0;
+		byte[] data = recvParams.get("HLAobjectInstanceCounts");
+		HLAinteger32BE count = encoders.createHLAinteger32BE();
+		count.decode( data );
+		offset += count.getEncodedLength();
+		Assert.assertEquals( count.getValue(), 1 );
+		
+		ObjectClassHandle oc = ocHandleFactory.decode( data, offset );
+		offset += oc.encodedLength();
+		Assert.assertEquals( oc, aHandle );
+		int instanceCount = BitHelpers.readIntBE( data, offset );
+		offset += 4;
+		Assert.assertEquals( instanceCount, 3 ); // The two actual instances of A, plus the one instance 
+		                                         // of A.B (discovered as A)
+	}
+	
+	////////////////////////////////////
+	// TEST: testRequestUpdatesSent() //
+	////////////////////////////////////
+	@Test(enabled=true)
+	public void testRequestUpdatesSent() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederate.HLArequest.HLArequestUpdatesSent" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportUpdatesSent" );
+		
+		ObjectClassHandleFactory ocHandleFactory = defaultFederate.rtiamb.getObjectClassHandleFactory();
+		FederateHandleFactory fedHandleFactory = defaultFederate.rtiamb.getFederateHandleFactory();
+		
+		ObjectClassHandle aHandle = defaultFederate.rtiamb.getObjectClassHandle( "HLAobjectRoot.A" );
+		ObjectClassHandle bHandle = defaultFederate.rtiamb.getObjectClassHandle( "HLAobjectRoot.A.B" );
+		
+		// Update some A instances
+		AttributeHandleValueMap ahvmpA = secondFederate.rtiamb.getAttributeHandleValueMapFactory().create( 3 );
+		ahvmpA.put( secondFederate.rtiamb.getAttributeHandle(aHandle, "aa"), new String("aa").getBytes() );
+		ahvmpA.put( secondFederate.rtiamb.getAttributeHandle(aHandle, "ab"), new String("ab").getBytes() );
+		ahvmpA.put( secondFederate.rtiamb.getAttributeHandle(aHandle, "ac"), new String("ac").getBytes() );
+		secondFederate.rtiamb.updateAttributeValues( new HLA1516eHandle(instanceHandle1), 
+		                                             ahvmpA, 
+		                                             null );
+		secondFederate.rtiamb.updateAttributeValues( new HLA1516eHandle(instanceHandle3), 
+		                                             ahvmpA, 
+		                                             null );
+		
+		// Update the B instance
+		AttributeHandleValueMap ahvmpB = secondFederate.rtiamb.getAttributeHandleValueMapFactory().create( 1 );
+		ahvmpB.put( secondFederate.rtiamb.getAttributeHandle(bHandle, "ba"), new String("ba").getBytes() );
+		ahvmpB.put( secondFederate.rtiamb.getAttributeHandle(bHandle, "bb"), new String("bb").getBytes() );
+		ahvmpB.put( secondFederate.rtiamb.getAttributeHandle(bHandle, "bc"), new String("bc").getBytes() );
+		secondFederate.rtiamb.updateAttributeValues( new HLA1516eHandle(instanceHandle4), 
+		                                             ahvmpB, 
+		                                             null );
+		
+		// And update it again!
+		secondFederate.rtiamb.updateAttributeValues( new HLA1516eHandle(instanceHandle4), 
+		                                             ahvmpB, 
+		                                             null );
+		
+		int secondHandle = secondFederate.federateHandle;
+		Map<String,byte[]> params = new HashMap<>();
+		ByteWrapper handleWrapper = new ByteWrapper( HLA1516eHandle.EncodedLength );
+		new HLA1516eHandle( secondHandle ).encode( handleWrapper );
+		params.put( "HLAfederate", handleWrapper.array() );
+		defaultFederate.quickSend( "HLAmanager.HLAfederate.HLArequest.HLArequestUpdatesSent", 
+		                           params, 
+		                           null );
+		
+		TestInteraction response = 
+			defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederate.HLAreport.HLAreportUpdatesSent" );
+		
+		Map<String,byte[]> recvParams = response.getParametersNamed( defaultFederate.rtiamb );
+		
+		// Handle should be the second federate
+		FederateHandle handle = fedHandleFactory.decode( recvParams.get("HLAfederate"), 0 );
+		Assert.assertEquals( handle, new HLA1516eHandle(secondHandle) );
+		
+		// HLAtransportation is unsupported at the moment, always HLAreliable
+		HLAunicodeString transportation = encoders.createHLAunicodeString();
+		transportation.decode( recvParams.get("HLAtransportation") );
+		Assert.assertEquals( transportation.getValue(), "HLAreliable" );
+		
+		// Should be a total of 2 entries
+		int offset = 0;
+		byte[] data = recvParams.get("HLAupdateCounts");
+		HLAinteger32BE count = encoders.createHLAinteger32BE();
+		count.decode( data );
+		offset += count.getEncodedLength();
+		Assert.assertEquals( count.getValue(), 2 );
+		
+		for( int i = 0 ; i < count.getValue() ; ++i )
+		{
+			ObjectClassHandle oc = ocHandleFactory.decode( data, offset );
+			offset += oc.encodedLength();
+			int updateCount = BitHelpers.readIntBE( data, offset );
+			offset += 4;
+			
+			if( oc.equals(aHandle) )
+				Assert.assertEquals( updateCount, 2 );
+			else if( oc.equals(bHandle) )
+				Assert.assertEquals( updateCount, 2 ); // 2 as the metric is total updates for the OC
+			else
+				Assert.fail( "Unexpected class handle in HLAupdateCounts: " + oc );
+		}
+	}
+
+	////////////////////////////////////////////
+	// TEST: testRequestReflectionsReceived() //
+	////////////////////////////////////////////
+	@Test(enabled=true)
+	public void testRequestReflectionsReceived() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederate.HLArequest.HLArequestReflectionsReceived" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportReflectionsReceived" );
+		
+		ObjectClassHandleFactory ocHandleFactory = defaultFederate.rtiamb.getObjectClassHandleFactory();
+		FederateHandleFactory fedHandleFactory = defaultFederate.rtiamb.getFederateHandleFactory();
+		
+		ObjectClassHandle aHandle = defaultFederate.rtiamb.getObjectClassHandle( "HLAobjectRoot.A" );
+		ObjectClassHandle bHandle = defaultFederate.rtiamb.getObjectClassHandle( "HLAobjectRoot.A.B" );
+		
+		// Update some A instances
+		AttributeHandleValueMap ahvmpA = secondFederate.rtiamb.getAttributeHandleValueMapFactory().create( 3 );
+		ahvmpA.put( secondFederate.rtiamb.getAttributeHandle(aHandle, "aa"), new String("aa").getBytes() );
+		ahvmpA.put( secondFederate.rtiamb.getAttributeHandle(aHandle, "ab"), new String("ab").getBytes() );
+		ahvmpA.put( secondFederate.rtiamb.getAttributeHandle(aHandle, "ac"), new String("ac").getBytes() );
+		secondFederate.rtiamb.updateAttributeValues( new HLA1516eHandle(instanceHandle1), 
+		                                             ahvmpA, 
+		                                             null );
+		secondFederate.rtiamb.updateAttributeValues( new HLA1516eHandle(instanceHandle3), 
+		                                             ahvmpA, 
+		                                             null );
+		
+		// Update the B instance
+		AttributeHandleValueMap ahvmpB = secondFederate.rtiamb.getAttributeHandleValueMapFactory().create( 1 );
+		ahvmpB.put( secondFederate.rtiamb.getAttributeHandle(bHandle, "ba"), new String("ba").getBytes() );
+		ahvmpB.put( secondFederate.rtiamb.getAttributeHandle(bHandle, "bb"), new String("bb").getBytes() );
+		ahvmpB.put( secondFederate.rtiamb.getAttributeHandle(bHandle, "bc"), new String("bc").getBytes() );
+		secondFederate.rtiamb.updateAttributeValues( new HLA1516eHandle(instanceHandle4), 
+		                                             ahvmpB, 
+		                                             null );
+		
+		// And update it again!
+		secondFederate.rtiamb.updateAttributeValues( new HLA1516eHandle(instanceHandle4), 
+		                                             ahvmpB, 
+		                                             null );
+		
+		int firstHandle = defaultFederate.federateHandle;
+		Map<String,byte[]> params = new HashMap<>();
+		ByteWrapper handleWrapper = new ByteWrapper( HLA1516eHandle.EncodedLength );
+		new HLA1516eHandle( firstHandle ).encode( handleWrapper );
+		params.put( "HLAfederate", handleWrapper.array() );
+		defaultFederate.quickSend( "HLAmanager.HLAfederate.HLArequest.HLArequestReflectionsReceived", 
+		                           params, 
+		                           null );
+		
+		TestInteraction response = 
+			defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederate.HLAreport.HLAreportReflectionsReceived" );
+		
+		Map<String,byte[]> recvParams = response.getParametersNamed( defaultFederate.rtiamb );
+		
+		// Handle should be the first federate
+		FederateHandle handle = fedHandleFactory.decode( recvParams.get("HLAfederate"), 0 );
+		Assert.assertEquals( handle, new HLA1516eHandle(firstHandle) );
+		
+		// HLAtransportation is unsupported at the moment, always HLAreliable
+		HLAunicodeString transportation = encoders.createHLAunicodeString();
+		transportation.decode( recvParams.get("HLAtransportation") );
+		Assert.assertEquals( transportation.getValue(), "HLAreliable" );
+		
+		// Should be a total of 1 entry (defaultFederate only subscribes to A)
+		int offset = 0;
+		byte[] data = recvParams.get("HLAreflectCounts");
+		HLAinteger32BE count = encoders.createHLAinteger32BE();
+		count.decode( data );
+		offset += count.getEncodedLength();
+		Assert.assertEquals( count.getValue(), 1 );
+		
+		ObjectClassHandle oc = ocHandleFactory.decode( data, offset );
+		offset += oc.encodedLength();
+		Assert.assertEquals( oc, aHandle );
+		int reflectCount = BitHelpers.readIntBE( data, offset );
+		offset += 4;
+			
+		Assert.assertEquals( reflectCount, 4 ); // 4 as the metric is total updates for the OC
+		                                         // 2 (A) + 2 (A.B discovered as A)
+	}
+	
+	///////////////////////////////////////////////////////
+	// TEST: testRequestObjectInstanceInformationOwned() //
+	///////////////////////////////////////////////////////
+	@Test(enabled=true)
+	public void testRequestObjectInstanceInformationOwned() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederate.HLArequest.HLArequestObjectInstanceInformation" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportObjectInstanceInformation" );
+		
+		ObjectClassHandleFactory ocHandleFactory = defaultFederate.rtiamb.getObjectClassHandleFactory();
+		FederateHandleFactory fedHandleFactory = defaultFederate.rtiamb.getFederateHandleFactory();
+		ObjectInstanceHandleFactory oiHandleFactory = defaultFederate.rtiamb.getObjectInstanceHandleFactory();
+		AttributeHandleFactory aHandleFactory = defaultFederate.rtiamb.getAttributeHandleFactory();
+		
+		ObjectClassHandle aHandle = defaultFederate.rtiamb.getObjectClassHandle( "HLAobjectRoot.A" );
+		ObjectClassHandle bHandle = defaultFederate.rtiamb.getObjectClassHandle( "HLAobjectRoot.A.B" );
+		
+		HLA1516eHandle i4Handle = new HLA1516eHandle( instanceHandle4 );
+		
+		// Request information from the perspective of the second federate
+		int secondHandle = secondFederate.federateHandle;
+		Map<String,byte[]> params = new HashMap<>();
+		ByteWrapper handleWrapper = new ByteWrapper( HLA1516eHandle.EncodedLength );
+		new HLA1516eHandle( secondHandle ).encode( handleWrapper );
+		params.put( "HLAfederate", handleWrapper.array() );
+		params.put( "HLAobjectInstance", i4Handle.getBytes() );
+		defaultFederate.quickSend( "HLAmanager.HLAfederate.HLArequest.HLArequestObjectInstanceInformation", 
+		                           params, 
+		                           null );
+		
+		TestInteraction response = 
+			defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederate.HLAreport.HLAreportObjectInstanceInformation" );
+		
+		Map<String,byte[]> recvParams = response.getParametersNamed( defaultFederate.rtiamb );
+		
+		// Handle should be the first federate
+		FederateHandle handle = fedHandleFactory.decode( recvParams.get("HLAfederate"), 0 );
+		Assert.assertEquals( handle, new HLA1516eHandle(secondHandle) );
+		
+		// Object Instance handle should match instance4
+		ObjectInstanceHandle instanceHandle = 
+			oiHandleFactory.decode( recvParams.get("HLAobjectInstance"), 0 );
+		Assert.assertEquals( instanceHandle, i4Handle );
+		
+		// Was originally registered as A.B
+		ObjectClassHandle registeredAs = ocHandleFactory.decode( recvParams.get("HLAregisteredClass"), 0 );
+		Assert.assertEquals( registeredAs, bHandle );
+		
+		// Second Federate is the registrant of instance4, but does not subscribe to it, therefore the
+		// known class should be invalid
+		ObjectClassHandle knownHandle = ocHandleFactory.decode( recvParams.get("HLAknownClass"), 0 );
+		Assert.assertEquals( knownHandle, new HLA1516eHandle(ObjectModel.INVALID_HANDLE) );
+		
+		// Second Federate owns all attributes of instance4
+		byte[] ownedAttributes = recvParams.get( "HLAownedInstanceAttributeList" );
+		int offset = 0;
+		HLAinteger32BE ownedAttributeCount = encoders.createHLAinteger32BE();
+		ownedAttributeCount.decode( ownedAttributes );
+		offset += ownedAttributeCount.getEncodedLength();
+		Assert.assertEquals( ownedAttributeCount.getValue(), 4 );
+		
+		// Are all expected attributes present? 
+		Set<String> expectedAttributes = new HashSet<>();
+		expectedAttributes.add( "ba" );
+		expectedAttributes.add( "bb" );
+		expectedAttributes.add( "bc" );
+		expectedAttributes.add( "HLAprivilegeToDeleteObject" );
+		
+		for( int i = 0 ; i < ownedAttributeCount.getValue() ; ++i )
+		{
+			AttributeHandle attrHandle = aHandleFactory.decode( ownedAttributes, offset );
+			offset += attrHandle.encodedLength();
+			
+			String attrName = defaultFederate.rtiamb.getAttributeName( bHandle, attrHandle );
+			Assert.assertTrue( expectedAttributes.contains(attrName) );
+			expectedAttributes.remove( attrName );
+		}
+		
+		Assert.assertTrue( expectedAttributes.isEmpty() );
+	}
+	
+	//////////////////////////////////////////////////////////
+	// TEST: testRequestObjectInstanceInformationNotOwned() //
+	//////////////////////////////////////////////////////////
+	@Test(enabled=true)
+	public void testRequestObjectInstanceInformationNotOwned() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederate.HLArequest.HLArequestObjectInstanceInformation" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportObjectInstanceInformation" );
+		
+		ObjectClassHandleFactory ocHandleFactory = defaultFederate.rtiamb.getObjectClassHandleFactory();
+		FederateHandleFactory fedHandleFactory = defaultFederate.rtiamb.getFederateHandleFactory();
+		ObjectInstanceHandleFactory oiHandleFactory = defaultFederate.rtiamb.getObjectInstanceHandleFactory();
+		ObjectClassHandle aHandle = defaultFederate.rtiamb.getObjectClassHandle( "HLAobjectRoot.A" );
+		ObjectClassHandle bHandle = defaultFederate.rtiamb.getObjectClassHandle( "HLAobjectRoot.A.B" );
+		
+		HLA1516eHandle i4Handle = new HLA1516eHandle( instanceHandle4 );
+		
+		// First request information from the perspective of the default federate
+		int firstHandle = defaultFederate.federateHandle;
+		Map<String,byte[]> params = new HashMap<>();
+		ByteWrapper handleWrapper = new ByteWrapper( HLA1516eHandle.EncodedLength );
+		new HLA1516eHandle( firstHandle ).encode( handleWrapper );
+		params.put( "HLAfederate", handleWrapper.array() );
+		params.put( "HLAobjectInstance", i4Handle.getBytes() );
+		defaultFederate.quickSend( "HLAmanager.HLAfederate.HLArequest.HLArequestObjectInstanceInformation", 
+		                           params, 
+		                           null );
+		
+		TestInteraction response = 
+			defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederate.HLAreport.HLAreportObjectInstanceInformation" );
+		
+		Map<String,byte[]> recvParams = response.getParametersNamed( defaultFederate.rtiamb );
+		
+		// Handle should be the first federate
+		FederateHandle handle = fedHandleFactory.decode( recvParams.get("HLAfederate"), 0 );
+		Assert.assertEquals( handle, new HLA1516eHandle(firstHandle) );
+		
+		// Object Instance handle should match instance4
+		ObjectInstanceHandle instanceHandle = 
+			oiHandleFactory.decode( recvParams.get("HLAobjectInstance"), 0 );
+		Assert.assertEquals( instanceHandle, i4Handle );
+		
+		// Was originally registered as A.B
+		ObjectClassHandle registeredAs = ocHandleFactory.decode( recvParams.get("HLAregisteredClass"), 0 );
+		Assert.assertEquals( registeredAs, bHandle );
+		
+		// However default federate is only subscribed to A, which is what it should be "known" as 
+		ObjectClassHandle knownAs = ocHandleFactory.decode( recvParams.get("HLAknownClass"), 0 );
+		Assert.assertEquals( knownAs, aHandle );
+		
+		// Default doesn't own any attributes of instance4
+		ByteWrapper ownedAttributes = new ByteWrapper( recvParams.get( "HLAownedInstanceAttributeList" ) );
+		HLAinteger32BE ownedAttributeCount = encoders.createHLAinteger32BE();
+		ownedAttributeCount.decode( ownedAttributes );
+		Assert.assertEquals( ownedAttributeCount.getValue(), 0 );
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	private class UnicodeStringFactory implements DataElementFactory<HLAunicodeString>
+	{
+		@Override
+		public HLAunicodeString createElement( int index )
+		{
+			return encoders.createHLAunicodeString();
+		}
+	}
+}

--- a/codebase/src/java/test/hlaunit/ieee1516e/mom/MomRequestPublicationsTest.java
+++ b/codebase/src/java/test/hlaunit/ieee1516e/mom/MomRequestPublicationsTest.java
@@ -1,0 +1,319 @@
+/*
+ *   Copyright 2016 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package hlaunit.ieee1516e.mom;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.portico.impl.hla1516e.types.HLA1516eHandle;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import hla.rti1516e.AttributeHandle;
+import hla.rti1516e.FederateHandle;
+import hla.rti1516e.FederateHandleFactory;
+import hla.rti1516e.InteractionClassHandle;
+import hla.rti1516e.InteractionClassHandleFactory;
+import hla.rti1516e.ObjectClassHandle;
+import hla.rti1516e.ObjectClassHandleFactory;
+import hla.rti1516e.RTIambassador;
+import hla.rti1516e.RtiFactoryFactory;
+import hla.rti1516e.encoding.ByteWrapper;
+import hla.rti1516e.encoding.DataElementFactory;
+import hla.rti1516e.encoding.DecoderException;
+import hla.rti1516e.encoding.EncoderFactory;
+import hla.rti1516e.encoding.HLAinteger32BE;
+import hla.rti1516e.encoding.HLAunicodeString;
+import hla.rti1516e.exceptions.CouldNotDecode;
+import hla.rti1516e.exceptions.FederateNotExecutionMember;
+import hla.rti1516e.exceptions.NotConnected;
+import hla.rti1516e.exceptions.RTIinternalError;
+import hlaunit.ieee1516e.common.Abstract1516eTest;
+import hlaunit.ieee1516e.common.TestFederate;
+import hlaunit.ieee1516e.common.TestInteraction;
+
+@Test(sequential=true, groups={"MomRequestPublicationsTest","mom"})
+public class MomRequestPublicationsTest extends Abstract1516eTest
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private TestFederate secondFederate;
+	private EncoderFactory encoders;
+	
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	/**
+	 * The spec says that HLAattributeList should be a HLAvariableArray of HLAhandle, however HLAhandle
+	 * doesn't implement the DataElement interface. Thus we can't create/decode the list using the
+	 * encoder factory :(
+	 */
+	private Set<AttributeHandle> decodeHLAattributeList( RTIambassador rtiamb, byte[] data )
+		throws DecoderException, 
+		       RTIinternalError, 
+		       NotConnected, 
+		       FederateNotExecutionMember, 
+		       CouldNotDecode
+	{
+		HLAinteger32BE hlaSize = encoders.createHLAinteger32BE();
+		hlaSize.decode( data );
+		int size = hlaSize.getValue();
+		
+		int offset = hlaSize.getEncodedLength();
+		Set<AttributeHandle> results = new HashSet<>( size );
+		for( int i = 0 ; i < size ; ++i )
+		{
+			AttributeHandle handle = rtiamb.getAttributeHandleFactory().decode( data, offset );
+			offset += handle.encodedLength();
+			results.add( handle );
+		}
+		
+		return results;
+	}
+	
+	/**
+	 * The spec says that HLAinteractionClassList should be a HLAvariableArray of HLAhandle, however 
+	 * HLAhandle doesn't implement the DataElement interface. Thus we can't create/decode the list using 
+	 * the encoder factory :(
+	 */
+	private Set<InteractionClassHandle> decodeHLAinteractionClassList( RTIambassador rtiamb, byte[] data )
+		throws DecoderException, 
+		       RTIinternalError, 
+		       NotConnected, 
+		       FederateNotExecutionMember, 
+		       CouldNotDecode
+	{
+		HLAinteger32BE hlaSize = encoders.createHLAinteger32BE();
+		hlaSize.decode( data );
+		int size = hlaSize.getValue();
+		
+		int offset = hlaSize.getEncodedLength();
+		Set<InteractionClassHandle> results = new HashSet<>( size );
+		for( int i = 0 ; i < size ; ++i )
+		{
+			InteractionClassHandle handle = rtiamb.getInteractionClassHandleFactory().decode( data, 
+			                                                                                  offset );
+			offset += handle.encodedLength();
+			results.add( handle );
+		}
+		
+		return results;
+	}
+	
+	@Override
+	@BeforeClass(alwaysRun=true)
+	public void beforeClass()
+	{
+		super.beforeClass();
+		
+		try
+		{
+			this.encoders = RtiFactoryFactory.getRtiFactory().getEncoderFactory();
+		}
+		catch( Exception e )
+		{
+			Assert.fail( "Could not create encoder factory " + e.getMessage(), e );
+		}
+	}
+	
+	@BeforeMethod(alwaysRun=true)
+	public void beforeMethod()
+	{
+		this.secondFederate = new TestFederate( "secondFederate", this );
+		this.secondFederate.quickConnect();
+		
+		defaultFederate.quickCreate();
+		defaultFederate.quickJoin();
+		secondFederate.quickJoin();
+	}
+	
+	@AfterMethod(alwaysRun=true)
+	public void afterMethod()
+	{
+		secondFederate.quickResign();
+		defaultFederate.quickResign();
+		defaultFederate.quickDestroy();
+	}
+	
+	@Override
+	@AfterClass(alwaysRun=true)
+	public void afterClass()
+	{
+		super.afterClass();
+	}
+	
+	//////////////////////////////////////////////////////////////////////////////////////////
+	////////////////////////////////////// Test Methods //////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////
+
+	///////////////////////////////////////////
+	// TEST: testRequestObjectPublications() //
+	///////////////////////////////////////////
+	@Test(enabled=true)
+	public void testRequestObjectPublications() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederate.HLArequest.HLArequestPublications" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportObjectClassPublication" );
+		
+		secondFederate.quickPublish( "HLAobjectRoot.A", "aa", "ac" );
+		secondFederate.quickPublish( "HLAobjectRoot.A.B", "bb" );
+		
+		int secondHandle = secondFederate.federateHandle;
+		Map<String,byte[]> params = new HashMap<>();
+		ByteWrapper handleWrapper = new ByteWrapper( HLA1516eHandle.EncodedLength );
+		new HLA1516eHandle( secondHandle ).encode( handleWrapper );
+		params.put( "HLAfederate", handleWrapper.array() );
+		defaultFederate.quickSend( "HLAmanager.HLAfederate.HLArequest.HLArequestPublications", 
+		                           params, 
+		                           null );
+		
+		FederateHandleFactory fedHandleFactory = defaultFederate.rtiamb.getFederateHandleFactory();
+		ObjectClassHandleFactory ocHandleFactory = defaultFederate.rtiamb.getObjectClassHandleFactory();
+		ObjectClassHandle aHandle = defaultFederate.rtiamb.getObjectClassHandle( "HLAobjectRoot.A" );
+		ObjectClassHandle bHandle = defaultFederate.rtiamb.getObjectClassHandle( "HLAobjectRoot.A.B" );
+		
+		// Should receive 2x HLAreportPublications, one for each object class
+		for( int i = 0 ; i < 2 ; ++i )
+		{
+			TestInteraction received =
+			    defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederate.HLAreport.HLAreportObjectClassPublication" );
+			
+			Map<String,byte[]> recvParams = received.getParametersNamed( defaultFederate.rtiamb );
+			
+			// Handle should be the second federate
+			FederateHandle handle = fedHandleFactory.decode( recvParams.get("HLAfederate"), 0 );
+			Assert.assertEquals( handle, new HLA1516eHandle(secondHandle) );
+			
+			// Should be a total of 2 classes being reported
+			HLAinteger32BE classCount = encoders.createHLAinteger32BE();
+			classCount.decode( recvParams.get("HLAnumberOfClasses") );
+			Assert.assertEquals( classCount.getValue(), 2 );
+			
+			ObjectClassHandle ocHandle = ocHandleFactory.decode( recvParams.get("HLAobjectClass"), 0 );
+			Set<AttributeHandle> attHandles = decodeHLAattributeList( defaultFederate.rtiamb, 
+			                                                          recvParams.get("HLAattributeList") );
+			
+			if( ocHandle.equals(aHandle) )
+			{
+				Assert.assertEquals( attHandles.size(), 3 );
+				Set<String> expecting = new HashSet<>();
+				expecting.add( "HLAprivilegeToDeleteObject" );
+				expecting.add( "aa" );
+				expecting.add( "ac" );
+				
+				for( AttributeHandle atthandle : attHandles )
+				{
+					String name = defaultFederate.rtiamb.getAttributeName( ocHandle, atthandle );
+					expecting.remove( name );
+				}
+				
+				// All expected attributes should have been processed, and none should remain in the
+				// "existing" set
+				Assert.assertEquals( expecting.size(), 0 );
+			}
+			else if( ocHandle.equals(bHandle) )
+			{
+				Assert.assertEquals( attHandles.size(), 2 );
+				Set<String> expecting = new HashSet<>();
+				expecting.add( "HLAprivilegeToDeleteObject" );
+				expecting.add( "bb" );
+				
+				for( AttributeHandle atthandle : attHandles )
+				{
+					String name = defaultFederate.rtiamb.getAttributeName( ocHandle, atthandle );
+					expecting.remove( name );
+				}
+				
+				// All expected attributes should have been processed, and none should remain in the
+				// "existing" set
+				Assert.assertEquals( expecting.size(), 0 );
+			}
+			else
+			{
+				Assert.fail( "Unexpected HLAreportObjectClassPublication received for OC " + ocHandle );
+			}
+		}
+	}
+	
+	////////////////////////////////////////////////
+	// TEST: testRequestInteractionPublications() //
+	////////////////////////////////////////////////
+	@Test(enabled=true)
+	public void testRequestInteractionPublications() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederate.HLArequest.HLArequestPublications" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportInteractionPublication" );
+		
+		secondFederate.quickPublish( "HLAinteractionRoot.X" );
+		secondFederate.quickPublish( "HLAinteractionRoot.X.Y" );
+		
+		int secondHandle = secondFederate.federateHandle;
+		Map<String,byte[]> params = new HashMap<>();
+		ByteWrapper handleWrapper = new ByteWrapper( HLA1516eHandle.EncodedLength );
+		new HLA1516eHandle( secondHandle ).encode( handleWrapper );
+		params.put( "HLAfederate", handleWrapper.array() );
+		defaultFederate.quickSend( "HLAmanager.HLAfederate.HLArequest.HLArequestPublications", 
+		                           params, 
+		                           null );
+		
+		FederateHandleFactory fedHandleFactory = defaultFederate.rtiamb.getFederateHandleFactory();
+		InteractionClassHandleFactory icHandleFactory = defaultFederate.rtiamb.getInteractionClassHandleFactory();
+		InteractionClassHandle xHandle = defaultFederate.rtiamb.getInteractionClassHandle( "HLAinteractionRoot.X" );
+		InteractionClassHandle yHandle = defaultFederate.rtiamb.getInteractionClassHandle( "HLAinteractionRoot.X.Y" );
+		
+		TestInteraction received =
+		    defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederate.HLAreport.HLAreportInteractionPublication" );
+		
+		Map<String,byte[]> recvParams = received.getParametersNamed( defaultFederate.rtiamb );
+		
+		// Handle should be the second federate
+		FederateHandle handle = fedHandleFactory.decode( recvParams.get("HLAfederate"), 0 );
+		Assert.assertEquals( handle, new HLA1516eHandle(secondHandle) );
+		
+		Set<InteractionClassHandle> interactions = 
+			decodeHLAinteractionClassList( defaultFederate.rtiamb, 
+			                               recvParams.get("HLAinteractionClassList") );
+		Assert.assertEquals( interactions.size(), 2 );
+		Assert.assertTrue( interactions.contains(xHandle) );
+		Assert.assertTrue( interactions.contains(yHandle) );
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	private class UnicodeStringFactory implements DataElementFactory<HLAunicodeString>
+	{
+		@Override
+		public HLAunicodeString createElement( int index )
+		{
+			return encoders.createHLAunicodeString();
+		}
+	}
+}

--- a/codebase/src/java/test/hlaunit/ieee1516e/mom/MomRequestSubscriptionsTest.java
+++ b/codebase/src/java/test/hlaunit/ieee1516e/mom/MomRequestSubscriptionsTest.java
@@ -1,0 +1,357 @@
+/*
+ *   Copyright 2016 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package hlaunit.ieee1516e.mom;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.portico.impl.hla1516e.types.HLA1516eHandle;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import hla.rti1516e.AttributeHandle;
+import hla.rti1516e.FederateHandle;
+import hla.rti1516e.FederateHandleFactory;
+import hla.rti1516e.InteractionClassHandle;
+import hla.rti1516e.InteractionClassHandleFactory;
+import hla.rti1516e.ObjectClassHandle;
+import hla.rti1516e.ObjectClassHandleFactory;
+import hla.rti1516e.RTIambassador;
+import hla.rti1516e.RtiFactoryFactory;
+import hla.rti1516e.encoding.ByteWrapper;
+import hla.rti1516e.encoding.DataElementFactory;
+import hla.rti1516e.encoding.DecoderException;
+import hla.rti1516e.encoding.EncoderFactory;
+import hla.rti1516e.encoding.HLAboolean;
+import hla.rti1516e.encoding.HLAinteger32BE;
+import hla.rti1516e.encoding.HLAunicodeString;
+import hla.rti1516e.exceptions.CouldNotDecode;
+import hla.rti1516e.exceptions.FederateNotExecutionMember;
+import hla.rti1516e.exceptions.NotConnected;
+import hla.rti1516e.exceptions.RTIinternalError;
+import hlaunit.ieee1516e.common.Abstract1516eTest;
+import hlaunit.ieee1516e.common.TestFederate;
+import hlaunit.ieee1516e.common.TestInteraction;
+
+@Test(sequential=true, groups={"MomRequestSubscriptionsTest","mom"})
+public class MomRequestSubscriptionsTest extends Abstract1516eTest
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private TestFederate secondFederate;
+	private EncoderFactory encoders;
+	
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	/**
+	 * The spec says that HLAattributeList should be a HLAvariableArray of HLAhandle, however HLAhandle
+	 * doesn't implement the DataElement interface. Thus we can't create/decode the list using the
+	 * encoder factory :(
+	 */
+	private Set<AttributeHandle> decodeHLAattributeList( RTIambassador rtiamb, byte[] data )
+		throws DecoderException, 
+		       RTIinternalError, 
+		       NotConnected, 
+		       FederateNotExecutionMember, 
+		       CouldNotDecode
+	{
+		HLAinteger32BE hlaSize = encoders.createHLAinteger32BE();
+		hlaSize.decode( data );
+		int size = hlaSize.getValue();
+		
+		int offset = hlaSize.getEncodedLength();
+		Set<AttributeHandle> results = new HashSet<>( size );
+		for( int i = 0 ; i < size ; ++i )
+		{
+			AttributeHandle handle = rtiamb.getAttributeHandleFactory().decode( data, offset );
+			offset += handle.encodedLength();
+			results.add( handle );
+		}
+		
+		return results;
+	}
+	
+	/**
+	 * The spec says that HLAinteractionClassList should be a HLAvariableArray of HLAhandle, however 
+	 * HLAhandle doesn't implement the DataElement interface. Thus we can't create/decode the list using 
+	 * the encoder factory :(
+	 */
+	private Set<InteractionClassHandle> decodeHLAinteractionClassList( RTIambassador rtiamb, byte[] data )
+		throws DecoderException, 
+		       RTIinternalError, 
+		       NotConnected, 
+		       FederateNotExecutionMember, 
+		       CouldNotDecode
+	{
+		HLAinteger32BE hlaSize = encoders.createHLAinteger32BE();
+		hlaSize.decode( data );
+		int size = hlaSize.getValue();
+		
+		int offset = hlaSize.getEncodedLength();
+		Set<InteractionClassHandle> results = new HashSet<>( size );
+		for( int i = 0 ; i < size ; ++i )
+		{
+			InteractionClassHandle handle = rtiamb.getInteractionClassHandleFactory().decode( data, 
+			                                                                                  offset );
+			offset += handle.encodedLength();
+			results.add( handle );
+		}
+		
+		return results;
+	}
+	
+	/**
+	 * The spec says that HLAinteractionSubList should be a HLAvariableArray of 
+	 * HLAinteractionSubscription, however HLAinteractionSubscription doesn't implement the DataElement 
+	 * interface. Thus we can't create/decode the list using the encoder factory :(
+	 */
+	private Set<InteractionClassHandle> decodeHLAinteractionSubList( RTIambassador rtiamb, byte[] data )
+		throws DecoderException, 
+		       RTIinternalError, 
+		       NotConnected, 
+		       FederateNotExecutionMember, 
+		       CouldNotDecode
+	{
+		HLAinteger32BE hlaSize = encoders.createHLAinteger32BE();
+		hlaSize.decode( data );
+		int size = hlaSize.getValue();
+		
+		int offset = hlaSize.getEncodedLength();
+		Set<InteractionClassHandle> results = new HashSet<>( size );
+		for( int i = 0 ; i < size ; ++i )
+		{
+			InteractionClassHandle handle = rtiamb.getInteractionClassHandleFactory().decode( data, 
+			                                                                                  offset );
+			offset += handle.encodedLength();
+			offset += 4;	// HLAactive
+			results.add( handle );
+		}
+		
+		return results;
+	}
+	
+	@Override
+	@BeforeClass(alwaysRun=true)
+	public void beforeClass()
+	{
+		super.beforeClass();
+		
+		try
+		{
+			this.encoders = RtiFactoryFactory.getRtiFactory().getEncoderFactory();
+		}
+		catch( Exception e )
+		{
+			Assert.fail( "Could not create encoder factory " + e.getMessage(), e );
+		}
+	}
+	
+	@BeforeMethod(alwaysRun=true)
+	public void beforeMethod()
+	{
+		this.secondFederate = new TestFederate( "secondFederate", this );
+		this.secondFederate.quickConnect();
+		
+		defaultFederate.quickCreate();
+		defaultFederate.quickJoin();
+		secondFederate.quickJoin();
+	}
+	
+	@AfterMethod(alwaysRun=true)
+	public void afterMethod()
+	{
+		secondFederate.quickResign();
+		defaultFederate.quickResign();
+		defaultFederate.quickDestroy();
+	}
+	
+	@Override
+	@AfterClass(alwaysRun=true)
+	public void afterClass()
+	{
+		super.afterClass();
+	}
+	
+	//////////////////////////////////////////////////////////////////////////////////////////
+	////////////////////////////////////// Test Methods //////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////
+
+	////////////////////////////////////////////
+	// TEST: testRequestObjectSubscriptions() //
+	////////////////////////////////////////////
+	@Test(enabled=true)
+	public void testRequestObjectSubscriptions() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederate.HLArequest.HLArequestSubscriptions" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportObjectClassSubscription" );
+		
+		secondFederate.quickSubscribe( "HLAobjectRoot.A", "aa", "ac" );
+		secondFederate.quickSubscribe( "HLAobjectRoot.A.B", "bb" );
+		
+		int secondHandle = secondFederate.federateHandle;
+		Map<String,byte[]> params = new HashMap<>();
+		ByteWrapper handleWrapper = new ByteWrapper( HLA1516eHandle.EncodedLength );
+		new HLA1516eHandle( secondHandle ).encode( handleWrapper );
+		params.put( "HLAfederate", handleWrapper.array() );
+		defaultFederate.quickSend( "HLAmanager.HLAfederate.HLArequest.HLArequestSubscriptions", 
+		                           params, 
+		                           null );
+		
+		FederateHandleFactory fedHandleFactory = defaultFederate.rtiamb.getFederateHandleFactory();
+		ObjectClassHandleFactory ocHandleFactory = defaultFederate.rtiamb.getObjectClassHandleFactory();
+		ObjectClassHandle aHandle = defaultFederate.rtiamb.getObjectClassHandle( "HLAobjectRoot.A" );
+		ObjectClassHandle bHandle = defaultFederate.rtiamb.getObjectClassHandle( "HLAobjectRoot.A.B" );
+		
+		// Should receive 2x HLAreportPublications, one for each object class
+		for( int i = 0 ; i < 2 ; ++i )
+		{
+			TestInteraction received =
+			    defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederate.HLAreport.HLAreportObjectClassSubscription" );
+			
+			Map<String,byte[]> recvParams = received.getParametersNamed( defaultFederate.rtiamb );
+			
+			// Handle should be the second federate
+			FederateHandle handle = fedHandleFactory.decode( recvParams.get("HLAfederate"), 0 );
+			Assert.assertEquals( handle, new HLA1516eHandle(secondHandle) );
+			
+			// Should be a total of 2 classes being reported
+			HLAinteger32BE classCount = encoders.createHLAinteger32BE();
+			classCount.decode( recvParams.get("HLAnumberOfClasses") );
+			Assert.assertEquals( classCount.getValue(), 2 );
+			
+			// HLAactive is not supported yet and is always set to TRUE
+			HLAboolean active = encoders.createHLAboolean();
+			active.decode( recvParams.get("HLAactive") );
+			Assert.assertEquals( active.getValue(), true );
+			
+			HLAunicodeString maxUpdateRate = encoders.createHLAunicodeString();
+			maxUpdateRate.decode( recvParams.get("HLAmaxUpdateRate") );
+			Assert.assertEquals( maxUpdateRate.getValue(), "None" );
+			
+			ObjectClassHandle ocHandle = ocHandleFactory.decode( recvParams.get("HLAobjectClass"), 0 );
+			Set<AttributeHandle> attHandles = decodeHLAattributeList( defaultFederate.rtiamb, 
+			                                                          recvParams.get("HLAattributeList") );
+			
+			if( ocHandle.equals(aHandle) )
+			{
+				Assert.assertEquals( attHandles.size(), 2 );
+				Set<String> expecting = new HashSet<>();
+				expecting.add( "aa" );
+				expecting.add( "ac" );
+				
+				for( AttributeHandle atthandle : attHandles )
+				{
+					String name = defaultFederate.rtiamb.getAttributeName( ocHandle, atthandle );
+					expecting.remove( name );
+				}
+				
+				// All expected attributes should have been processed, and none should remain in the
+				// "existing" set
+				Assert.assertEquals( expecting.size(), 0 );
+			}
+			else if( ocHandle.equals(bHandle) )
+			{
+				Assert.assertEquals( attHandles.size(), 1 );
+				Set<String> expecting = new HashSet<>();
+				expecting.add( "bb" );
+				
+				for( AttributeHandle atthandle : attHandles )
+				{
+					String name = defaultFederate.rtiamb.getAttributeName( ocHandle, atthandle );
+					expecting.remove( name );
+				}
+				
+				// All expected attributes should have been processed, and none should remain in the
+				// "existing" set
+				Assert.assertEquals( expecting.size(), 0 );
+			}
+			else
+			{
+				Assert.fail( "Unexpected HLAreportObjectClassSubscription received for OC " + ocHandle );
+			}
+		}
+	}
+	
+	/////////////////////////////////////////////////
+	// TEST: testRequestInteractionSubscriptions() //
+	/////////////////////////////////////////////////
+	@Test(enabled=true)
+	public void testRequestInteractionSubscriptions() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederate.HLArequest.HLArequestSubscriptions" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportInteractionSubscription" );
+		
+		secondFederate.quickSubscribe( "HLAinteractionRoot.X" );
+		secondFederate.quickSubscribe( "HLAinteractionRoot.X.Y" );
+		
+		int secondHandle = secondFederate.federateHandle;
+		Map<String,byte[]> params = new HashMap<>();
+		ByteWrapper handleWrapper = new ByteWrapper( HLA1516eHandle.EncodedLength );
+		new HLA1516eHandle( secondHandle ).encode( handleWrapper );
+		params.put( "HLAfederate", handleWrapper.array() );
+		defaultFederate.quickSend( "HLAmanager.HLAfederate.HLArequest.HLArequestSubscriptions", 
+		                           params, 
+		                           null );
+		
+		FederateHandleFactory fedHandleFactory = defaultFederate.rtiamb.getFederateHandleFactory();
+		InteractionClassHandleFactory icHandleFactory = defaultFederate.rtiamb.getInteractionClassHandleFactory();
+		InteractionClassHandle xHandle = defaultFederate.rtiamb.getInteractionClassHandle( "HLAinteractionRoot.X" );
+		InteractionClassHandle yHandle = defaultFederate.rtiamb.getInteractionClassHandle( "HLAinteractionRoot.X.Y" );
+		
+		TestInteraction received =
+		    defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederate.HLAreport.HLAreportInteractionSubscription" );
+		
+		Map<String,byte[]> recvParams = received.getParametersNamed( defaultFederate.rtiamb );
+		
+		// Handle should be the second federate
+		FederateHandle handle = fedHandleFactory.decode( recvParams.get("HLAfederate"), 0 );
+		Assert.assertEquals( handle, new HLA1516eHandle(secondHandle) );
+		
+		Set<InteractionClassHandle> interactions = 
+			decodeHLAinteractionSubList( defaultFederate.rtiamb, 
+			                             recvParams.get("HLAinteractionClassList") );
+		Assert.assertEquals( interactions.size(), 2 );
+		Assert.assertTrue( interactions.contains(xHandle) );
+		Assert.assertTrue( interactions.contains(yHandle) );
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	private class UnicodeStringFactory implements DataElementFactory<HLAunicodeString>
+	{
+		@Override
+		public HLAunicodeString createElement( int index )
+		{
+			return encoders.createHLAunicodeString();
+		}
+	}
+}

--- a/codebase/src/java/test/hlaunit/ieee1516e/mom/MomRequestSynchronizationPoints.java
+++ b/codebase/src/java/test/hlaunit/ieee1516e/mom/MomRequestSynchronizationPoints.java
@@ -1,0 +1,222 @@
+/*
+ *   Copyright 2016 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package hlaunit.ieee1516e.mom;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.portico.impl.hla1516e.types.HLA1516eHandle;
+import org.portico.utils.bithelpers.BitHelpers;
+import org.portico2.rti.services.mom.data.SynchPointFederate.SynchPointStatus;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import hla.rti1516e.FederateHandle;
+import hla.rti1516e.FederateHandleFactory;
+import hla.rti1516e.RtiFactoryFactory;
+import hla.rti1516e.encoding.ByteWrapper;
+import hla.rti1516e.encoding.EncoderFactory;
+import hla.rti1516e.encoding.HLAinteger32BE;
+import hla.rti1516e.encoding.HLAunicodeString;
+import hlaunit.ieee1516e.common.Abstract1516eTest;
+import hlaunit.ieee1516e.common.TestFederate;
+import hlaunit.ieee1516e.common.TestInteraction;
+
+@Test(sequential=true, groups={"MomRequestSynchronizationPoints","mom"})
+public class MomRequestSynchronizationPoints extends Abstract1516eTest
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private TestFederate secondFederate;
+	private EncoderFactory encoders;
+	
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	@BeforeClass(alwaysRun=true)
+	public void beforeClass()
+	{
+		super.beforeClass();
+		
+		try
+		{
+			this.encoders = RtiFactoryFactory.getRtiFactory().getEncoderFactory();
+		}
+		catch( Exception e )
+		{
+			Assert.fail( "Could not create encoder factory " + e.getMessage(), e );
+		}
+	}
+	
+	@BeforeMethod(alwaysRun=true)
+	public void beforeMethod()
+	{
+		this.secondFederate = new TestFederate( "secondFederate", this );
+		this.secondFederate.quickConnect();
+		
+		defaultFederate.quickCreate();
+		defaultFederate.quickJoin();
+		secondFederate.quickJoin();
+		
+		
+	}
+	
+	@AfterMethod(alwaysRun=true)
+	public void afterMethod()
+	{
+		secondFederate.quickResign();
+		defaultFederate.quickResign();
+		defaultFederate.quickDestroy();
+	}
+	
+	@Override
+	@AfterClass(alwaysRun=true)
+	public void afterClass()
+	{
+		super.afterClass();
+	}
+	
+	//////////////////////////////////////////////////////////////////////////////////////////
+	////////////////////////////////////// Test Methods //////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////
+	@Test(enabled=true)
+	public void testRequestSynchronizationPoints() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederation.HLArequest.HLArequestSynchronizationPoints" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederation.HLAreport.HLAreportSynchronizationPoints" );
+		
+		secondFederate.quickAnnounce( "achieved", null );
+		secondFederate.quickAnnounce( "test1", null );
+		secondFederate.quickAnnounce( "test2", null );
+		secondFederate.quickAnnounce( "test3", null );
+		
+		defaultFederate.quickAchieved( "achieved" );
+		secondFederate.quickAchieved( "achieved" );
+		defaultFederate.fedamb.waitForSynchronized( "achieved" );
+		
+		defaultFederate.quickSend( "HLAmanager.HLAfederation.HLArequest.HLArequestSynchronizationPoints" );
+		TestInteraction response = 
+			defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederation.HLAreport.HLAreportSynchronizationPoints" );
+		
+		Map<String,byte[]> responseParams = response.getParametersNamed( defaultFederate.rtiamb );
+		ByteWrapper syncpoints = new ByteWrapper( responseParams.get("HLAsyncPoints") );
+		HLAinteger32BE recordCount = encoders.createHLAinteger32BE();
+		recordCount.decode( syncpoints );
+		
+		// HLAreportSynchronizationPoints should only report "in-progress" syncpoints, therefore we
+		// should only have 3 in our response
+		Assert.assertEquals( recordCount.getValue(), 3 );
+		
+		// Are they the syncpoints we were expecting?
+		Set<String> expectedLabels = new HashSet<>();
+		expectedLabels.add( "test1" );
+		expectedLabels.add( "test2" );
+		expectedLabels.add( "test3" );
+		for( int i = 0 ; i < recordCount.getValue() ; ++i )
+		{
+			HLAunicodeString label = encoders.createHLAunicodeString();
+			label.decode( syncpoints );
+			String labelValue = label.getValue();
+			
+			Assert.assertTrue( expectedLabels.contains(labelValue) );
+			expectedLabels.remove( labelValue );
+		}
+		
+		Assert.assertTrue( expectedLabels.isEmpty() );
+	}
+	
+	@Test(enabled=true)
+	public void testRequestSynchronizationPointStatus() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederation.HLArequest.HLArequestSynchronizationPointStatus" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederation.HLAreport.HLAreportSynchronizationPointStatus" );
+	
+		FederateHandleFactory fedHandleFactory = defaultFederate.rtiamb.getFederateHandleFactory();
+		FederateHandle defaultFedHandle = new HLA1516eHandle( defaultFederate.federateHandle );
+		FederateHandle secondFedHandle = new HLA1516eHandle( secondFederate.federateHandle );
+		
+		secondFederate.quickAnnounce( "test1", null );
+		secondFederate.quickAnnounce( "test2", null );
+		
+		// Have the default federate achieve test1
+		defaultFederate.quickAchieved( "test1" );
+		
+		Map<String,byte[]> requestParams = new HashMap<>();
+		requestParams.put( "HLAsyncPointName", encoders.createHLAunicodeString("test1").toByteArray() );
+		defaultFederate.quickSend( "HLAmanager.HLAfederation.HLArequest.HLArequestSynchronizationPointStatus",
+		                           requestParams,
+		                           null );
+		TestInteraction response = 
+			defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederation.HLAreport.HLAreportSynchronizationPointStatus" );
+		
+		Map<String,byte[]> responseParams = response.getParametersNamed( defaultFederate.rtiamb );
+		HLAunicodeString syncpointName = encoders.createHLAunicodeString();
+		syncpointName.decode( responseParams.get("HLAsyncPointName") );
+		Assert.assertEquals( syncpointName.getValue(), "test1" );
+		
+		byte[] syncpointFederates = responseParams.get( "HLAsyncPointFederates" );
+		int offset = 0;
+		int recordCount = BitHelpers.readIntBE( syncpointFederates, offset );
+		offset += 4;
+		
+		// Expecting two records, one for each federate
+		Assert.assertEquals( recordCount, 2 );
+		
+		for( int i = 0 ; i < recordCount ; ++i )
+		{
+			FederateHandle fedHandle = fedHandleFactory.decode( syncpointFederates, offset );
+			offset += fedHandle.encodedLength();
+			
+			int statusRaw = BitHelpers.readIntBE( syncpointFederates, offset );
+			SynchPointStatus status = SynchPointStatus.values()[statusRaw];
+			offset += 4;
+			
+			if( fedHandle.equals(defaultFedHandle) )
+			{
+				// Default federate has achieved the syncpoint, and is waiting for the other federate
+				Assert.assertEquals( status, SynchPointStatus.WaitingForRestOfFederation );
+			}
+			else if( fedHandle.equals(secondFedHandle) )
+			{
+				// Second federate has not achieved the syncpoint
+				Assert.assertEquals( status, SynchPointStatus.NoActivity );
+			}
+			else
+			{
+				Assert.fail( "Unexpected fed handle: " + fedHandle );
+			}
+		}
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/test/hlaunit/ieee1516e/mom/MomServiceReportingTest.java
+++ b/codebase/src/java/test/hlaunit/ieee1516e/mom/MomServiceReportingTest.java
@@ -1,0 +1,415 @@
+/*
+ *   Copyright 2016 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package hlaunit.ieee1516e.mom;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.portico.impl.hla1516e.types.HLA1516eHandle;
+import org.portico.impl.hla1516e.types.encoding.HLA1516eBoolean;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import hla.rti1516e.FederateHandle;
+import hla.rti1516e.ObjectClassHandle;
+import hla.rti1516e.RTIambassador;
+import hla.rti1516e.RtiFactoryFactory;
+import hla.rti1516e.encoding.ByteWrapper;
+import hla.rti1516e.encoding.DataElementFactory;
+import hla.rti1516e.encoding.EncoderFactory;
+import hla.rti1516e.encoding.HLAboolean;
+import hla.rti1516e.encoding.HLAunicodeString;
+import hla.rti1516e.encoding.HLAvariableArray;
+import hla.rti1516e.exceptions.NameNotFound;
+import hlaunit.ieee1516e.common.Abstract1516eTest;
+import hlaunit.ieee1516e.common.TestFederate;
+import hlaunit.ieee1516e.common.TestInteraction;
+
+@Test(sequential=true, groups={"MomServiceReportingTest","mom"})
+public class MomServiceReportingTest extends Abstract1516eTest
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private TestFederate secondFederate;
+	private EncoderFactory encoders;
+	
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	@BeforeClass(alwaysRun=true)
+	public void beforeClass()
+	{
+		super.beforeClass();
+		
+		try
+		{
+			this.encoders = RtiFactoryFactory.getRtiFactory().getEncoderFactory();
+		}
+		catch( Exception e )
+		{
+			Assert.fail( "Could not create encoder factory " + e.getMessage(), e );
+		}
+	}
+	
+	@BeforeMethod(alwaysRun=true)
+	public void beforeMethod()
+	{
+		this.secondFederate = new TestFederate( "secondFederate", this );
+		this.secondFederate.quickConnectWithImmediateCallbacks();
+		
+		defaultFederate.quickCreate();
+		defaultFederate.quickJoin();
+		secondFederate.quickJoin();
+	}
+	
+	@AfterMethod(alwaysRun=true)
+	public void afterMethod()
+	{
+		secondFederate.quickResign();
+		defaultFederate.quickResign();
+		defaultFederate.quickDestroy();
+	}
+	
+	@Override
+	@AfterClass(alwaysRun=true)
+	public void afterClass()
+	{
+		super.afterClass();
+	}
+	
+	//////////////////////////////////////////////////////////////////////////////////////////
+	////////////////////////////////////// Test Methods //////////////////////////////////////
+	//////////////////////////////////////////////////////////////////////////////////////////
+
+	///////////////////////////////////////////////////////////
+	// TEST: testEnableServiceReportingWithFedAmbCallbacks() //
+	///////////////////////////////////////////////////////////
+	@Test(enabled=true)
+	public void testEnableServiceReportingWithFedAmbCallbacks() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederate.HLAadjust.HLAsetServiceReporting" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportServiceInvocation" );
+		int secondHandle = secondFederate.federateHandle;
+		Map<String,byte[]> params = new HashMap<>();
+		ByteWrapper handleWrapper = new ByteWrapper( HLA1516eHandle.EncodedLength );
+		new HLA1516eHandle( secondHandle ).encode( handleWrapper );
+		params.put( "HLAfederate", handleWrapper.array() );
+		params.put( "HLAreportingState", new HLA1516eBoolean(true).toByteArray() );
+		defaultFederate.quickSend( "HLAmanager.HLAfederate.HLAadjust.HLAsetServiceReporting", 
+		                           params, 
+		                           null );
+		
+		// Sleep for a bit to let the switch turn on
+		Thread.sleep( 100 );
+		RTIambassador rtiamb2 = secondFederate.getRtiAmb();
+		
+		// Registering a sync point should result in 3 service invocations, however their order is
+		// not guaranteed. All should be a success result though
+		rtiamb2.registerFederationSynchronizationPoint( "test",
+		                                                new String("Hello").getBytes() );
+		for( int i = 0 ; i < 3 ; ++i )
+		{
+			TestInteraction received =
+			    defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederate.HLAreport.HLAreportServiceInvocation" );
+			Map<String,byte[]> paramMap = received.getParametersNamed( defaultFederate.rtiamb );
+
+			FederateHandle federateHandle = 
+				defaultFederate.rtiamb.getFederateHandleFactory().decode( paramMap.get("HLAfederate"), 0 );
+			Assert.assertEquals( federateHandle, 
+			                     new HLA1516eHandle(secondFederate.federateHandle) );
+			
+			HLAunicodeString hlaService = encoders.createHLAunicodeString();
+			hlaService.decode( paramMap.get( "HLAservice" ) );
+			String service = hlaService.getValue();
+			
+			HLAboolean hlaSuccessIndicator = encoders.createHLAboolean();
+			hlaSuccessIndicator.decode( paramMap.get( "HLAsuccessIndicator" ) );
+			boolean successIndicator = hlaSuccessIndicator.getValue();
+			Assert.assertEquals( hlaSuccessIndicator.getValue(), true );
+
+			HLAunicodeString hlaException = encoders.createHLAunicodeString();
+			hlaException.decode( paramMap.get("HLAexception") );
+			String exception = hlaException.getValue().trim();
+			Assert.assertTrue( exception.isEmpty() );
+			
+			HLAvariableArray<HLAunicodeString> suppliedArgs =
+			    encoders.createHLAvariableArray( new UnicodeStringFactory() );
+			suppliedArgs.decode( paramMap.get( "HLAsuppliedArguments" ) );
+			
+			HLAvariableArray<HLAunicodeString> returnedArgs =
+			    encoders.createHLAvariableArray( new UnicodeStringFactory() );
+			returnedArgs.decode( paramMap.get( "HLAreturnedArguments" ) );
+			
+			if( service.equals("registerFederationSynchronizationPoint") )
+			{
+				//
+				// rtiamb.registerFederationSynchronizationPoint( "test", {0x48,0x65,0x6c,0x6c,0x6f} );
+				//
+				Assert.assertEquals( suppliedArgs.size(), 2 );
+				HLAunicodeString syncpointName = suppliedArgs.get( 0 );
+				Assert.assertEquals( syncpointName.getValue(), "test" );
+				HLAunicodeString tag = suppliedArgs.get( 1 );
+				Assert.assertEquals( tag.getValue(), "[0x48,0x65,0x6c,0x6c,0x6f]" );
+				
+				Assert.assertEquals( returnedArgs.size(), 0 );
+			}
+			else if( service.equals( "synchronizationPointRegistrationSucceeded") )
+			{
+				//
+				// fedamb.synchronizationPointRegistrationSucceeded( "test" );
+				//
+				Assert.assertEquals( successIndicator, true );
+				
+				Assert.assertEquals( suppliedArgs.size(), 1 );
+				HLAunicodeString label = suppliedArgs.get( 0 );
+				Assert.assertEquals( label.getValue(), "test" );
+				
+				Assert.assertEquals( returnedArgs.size(), 0 );
+				
+				Assert.assertTrue( exception.isEmpty() );
+			}
+			else if( service.equals( "announceSynchronizationPoint") )
+			{
+				//
+				// fedamb.announceSynchronizationPoint( "test", {0x48,0x65,0x6c,0x6c,0x6f} );
+				//
+				Assert.assertEquals( successIndicator, true );
+				
+				Assert.assertEquals( suppliedArgs.size(), 2 );
+				HLAunicodeString syncpointName = suppliedArgs.get( 0 );
+				Assert.assertEquals( syncpointName.getValue(), "test" );
+				HLAunicodeString tag = suppliedArgs.get( 1 );
+				Assert.assertEquals( tag.getValue(), "[0x48,0x65,0x6c,0x6c,0x6f]" );
+				
+				Assert.assertEquals( returnedArgs.size(), 0 );
+				
+				Assert.assertTrue( exception.isEmpty() );
+			}
+			else
+			{
+				Assert.fail( "Received unexpceted service invocation report for " + service  );
+			}
+		}
+	}
+	
+	///////////////////////////////////////////////////////////
+	// TEST: testEnableServiceReportingWithReturnArguments() //
+	///////////////////////////////////////////////////////////
+	@Test(enabled=true)
+	public void testEnableServiceReportingWithReturnArguments() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederate.HLAadjust.HLAsetServiceReporting" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportServiceInvocation" );
+		int secondHandle = secondFederate.federateHandle;
+		Map<String,byte[]> params = new HashMap<>();
+		ByteWrapper handleWrapper = new ByteWrapper( HLA1516eHandle.EncodedLength );
+		new HLA1516eHandle( secondHandle ).encode( handleWrapper );
+		params.put( "HLAfederate", handleWrapper.array() );
+		params.put( "HLAreportingState", new HLA1516eBoolean(true).toByteArray() );
+		defaultFederate.quickSend( "HLAmanager.HLAfederate.HLAadjust.HLAsetServiceReporting", 
+		                           params, 
+		                           null );
+		
+		// Sleep for a bit to let the switch turn on
+		Thread.sleep( 100 );
+		RTIambassador rtiamb2 = secondFederate.getRtiAmb();
+		
+		ObjectClassHandle ocHandle = rtiamb2.getObjectClassHandle( "HLAmanager.HLAfederation" );
+
+		TestInteraction received =
+		    defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederate.HLAreport.HLAreportServiceInvocation" );
+		Map<String,byte[]> paramMap = received.getParametersNamed( defaultFederate.rtiamb );
+
+		FederateHandle federateHandle = 
+			defaultFederate.rtiamb.getFederateHandleFactory().decode( paramMap.get("HLAfederate"), 0 );
+		Assert.assertEquals( federateHandle, 
+		                     new HLA1516eHandle(secondFederate.federateHandle) );
+		
+		// Service should be getObjectClassHandle
+		HLAunicodeString hlaService = encoders.createHLAunicodeString();
+		hlaService.decode( paramMap.get( "HLAservice" ) );
+		String service = hlaService.getValue();
+		Assert.assertEquals( service, "getObjectClassHandle" );
+		
+		// Success should be true
+		HLAboolean hlaSuccessIndicator = encoders.createHLAboolean();
+		hlaSuccessIndicator.decode( paramMap.get( "HLAsuccessIndicator" ) );
+		boolean successIndicator = hlaSuccessIndicator.getValue();
+		Assert.assertEquals( hlaSuccessIndicator.getValue(), true );
+
+		// Exception should be empty
+		HLAunicodeString hlaException = encoders.createHLAunicodeString();
+		hlaException.decode( paramMap.get("HLAexception") );
+		String exception = hlaException.getValue().trim();
+		Assert.assertTrue( exception.isEmpty() );
+		
+		// Should be one supplied argument - "HLAmanager.HLAfederation"
+		HLAvariableArray<HLAunicodeString> suppliedArgs =
+		    encoders.createHLAvariableArray( new UnicodeStringFactory() );
+		suppliedArgs.decode( paramMap.get( "HLAsuppliedArguments" ) );
+		Assert.assertEquals( suppliedArgs.size(), 1 );
+		Assert.assertEquals( suppliedArgs.get(0).getValue(), "HLAmanager.HLAfederation" );
+		
+		// Should be on returned argument which matches the return from the function call
+		HLAvariableArray<HLAunicodeString> returnedArgs =
+		    encoders.createHLAvariableArray( new UnicodeStringFactory() );
+		returnedArgs.decode( paramMap.get( "HLAreturnedArguments" ) );
+		Assert.assertEquals( returnedArgs.size(), 1 );
+		Assert.assertEquals( returnedArgs.get(0).getValue(), ocHandle.toString() );
+	}
+	
+	//////////////////////////////////////////////////////
+	// TEST: testEnableServiceReportingWithFailedCall() //
+	//////////////////////////////////////////////////////
+	@Test(enabled=true)
+	public void testEnableServiceReportingWithFailedCall() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederate.HLAadjust.HLAsetServiceReporting" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportServiceInvocation" );
+		
+		int secondHandle = secondFederate.federateHandle;
+		Map<String,byte[]> params = new HashMap<>();
+		ByteWrapper handleWrapper = new ByteWrapper( HLA1516eHandle.EncodedLength );
+		new HLA1516eHandle( secondHandle ).encode( handleWrapper );
+		params.put( "HLAfederate", handleWrapper.array() );
+		params.put( "HLAreportingState", new HLA1516eBoolean(true).toByteArray() );
+		defaultFederate.quickSend( "HLAmanager.HLAfederate.HLAadjust.HLAsetServiceReporting", 
+		                           params, 
+		                           null );
+		
+		// Sleep for a bit to let the switch turn on
+		Thread.sleep( 100 );
+		
+		try
+		{
+			secondFederate.rtiamb.getObjectClassHandle( "BogusClass" );
+		}
+		catch( NameNotFound nnf )
+		{
+			//
+		}
+		
+		TestInteraction received =
+		    defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederate.HLAreport.HLAreportServiceInvocation" );
+		Map<String,byte[]> paramMap = received.getParametersNamed( defaultFederate.rtiamb );
+
+		FederateHandle federateHandle = 
+			defaultFederate.rtiamb.getFederateHandleFactory().decode( paramMap.get("HLAfederate"), 0 );
+		Assert.assertEquals( federateHandle, 
+		                     new HLA1516eHandle(secondFederate.federateHandle) );
+		
+		// Service should be getObjectClassHandle
+		HLAunicodeString hlaService = encoders.createHLAunicodeString();
+		hlaService.decode( paramMap.get( "HLAservice" ) );
+		String service = hlaService.getValue();
+		Assert.assertEquals( service, "getObjectClassHandle" );
+		
+		// Success should be false
+		HLAboolean hlaSuccessIndicator = encoders.createHLAboolean();
+		hlaSuccessIndicator.decode( paramMap.get( "HLAsuccessIndicator" ) );
+		boolean successIndicator = hlaSuccessIndicator.getValue();
+		Assert.assertEquals( hlaSuccessIndicator.getValue(), false );
+
+		// Exception should not be empty!
+		HLAunicodeString hlaException = encoders.createHLAunicodeString();
+		hlaException.decode( paramMap.get("HLAexception") );
+		String exception = hlaException.getValue().trim();
+		Assert.assertFalse( exception.isEmpty() );
+		Assert.assertEquals( exception, "name not found" );
+		
+		// Should be one supplied argument - "BogusClass"
+		HLAvariableArray<HLAunicodeString> suppliedArgs =
+		    encoders.createHLAvariableArray( new UnicodeStringFactory() );
+		suppliedArgs.decode( paramMap.get( "HLAsuppliedArguments" ) );
+		Assert.assertEquals( suppliedArgs.size(), 1 );
+		Assert.assertEquals( suppliedArgs.get(0).getValue(), "BogusClass" );
+		
+		// Should be on returned argument which matches the return from the function call
+		HLAvariableArray<HLAunicodeString> returnedArgs =
+		    encoders.createHLAvariableArray( new UnicodeStringFactory() );
+		returnedArgs.decode( paramMap.get( "HLAreturnedArguments" ) );
+		Assert.assertEquals( returnedArgs.size(), 0 );
+	}
+	
+	@Test(enabled=true)
+	public void testEnableServiceReportingOnRSISubscriber() throws Exception
+	{
+		defaultFederate.quickPublish( "HLAmanager.HLAfederate.HLAadjust.HLAsetServiceReporting" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportServiceInvocation" );
+		defaultFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportMOMexception" );
+		
+		// Have the second federate subscribe to HLAreportServiceInvocation - this should cause the
+		// subsequent request to enable service reporting on the federate to fail
+		secondFederate.quickSubscribe( "HLAmanager.HLAfederate.HLAreport.HLAreportServiceInvocation" );
+		
+		// Request that service reporting be enabled on the second federate
+		int secondHandle = secondFederate.federateHandle;
+		Map<String,byte[]> params = new HashMap<>();
+		ByteWrapper handleWrapper = new ByteWrapper( HLA1516eHandle.EncodedLength );
+		new HLA1516eHandle( secondHandle ).encode( handleWrapper );
+		params.put( "HLAfederate", handleWrapper.array() );
+		params.put( "HLAreportingState", new HLA1516eBoolean(true).toByteArray() );
+		defaultFederate.quickSend( "HLAmanager.HLAfederate.HLAadjust.HLAsetServiceReporting", 
+		                           params, 
+		                           null );
+		
+		// Sleep for a bit to let the call go through
+		Thread.sleep( 100 );
+		
+		// A MOM Exception should be reported for the second federate
+		TestInteraction received =
+		    defaultFederate.fedamb.waitForROInteraction( "HLAmanager.HLAfederate.HLAreport.HLAreportMOMexception" );
+		Map<String,byte[]> paramMap = received.getParametersNamed( defaultFederate.rtiamb );
+
+		// Exception should be for the HLAsetServiceReporting service
+		HLAunicodeString service = encoders.createHLAunicodeString();
+		service.decode( paramMap.get("HLAservice") );
+		Assert.assertEquals( service.getValue(), 
+		                     "HLAinteractionRoot.HLAmanager.HLAfederate.HLAadjust.HLAsetServiceReporting" );
+		
+		// Exception should be raised against the requestor
+		FederateHandle defaultHandle = new HLA1516eHandle( defaultFederate.federateHandle );
+		FederateHandle federateHandle = 
+			defaultFederate.rtiamb.getFederateHandleFactory().decode( paramMap.get("HLAfederate"), 0 );
+		Assert.assertEquals( federateHandle, 
+		                     defaultHandle );
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	private class UnicodeStringFactory implements DataElementFactory<HLAunicodeString>
+	{
+		@Override
+		public HLAunicodeString createElement( int index )
+		{
+			return encoders.createHLAunicodeString();
+		}
+	}
+}


### PR DESCRIPTION
- Added some remedial unit tests for the newly supported MOM interactions
- `HLAreportMomException` fixed so that it now includes the `HLAfederate` parameter, populated with handle of the federate that invoked the service
- `HLAreportObjectInstanceInformation` now returns a `HLAknownClass` value of `ObjectModel.INVALID_HANDLE` if the context federate owns the object but has not discovered it
- `HLAreportSynchronizationPoints` now only returns sync points that are "in-progress" as per the spec