### PR TITLE
Joined check on RTI-side Federation message handlers #276

### DIFF
--- a/codebase/src/java/portico/org/portico2/rti/cli/EnvironmentVariables.java
+++ b/codebase/src/java/portico/org/portico2/rti/cli/EnvironmentVariables.java
@@ -1,0 +1,123 @@
+/*
+ *   Copyright 2018 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.rti.cli;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import java.util.function.Supplier;
+
+import org.portico.lrc.PorticoConstants;
+
+public class EnvironmentVariables
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private Map<String,Supplier<String>> suppliers;
+	private RtiCli container;
+	
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public EnvironmentVariables( RtiCli container )
+	{
+		this.container = container;
+		this.suppliers = new HashMap<>();
+		initialize();
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	private void initialize()
+	{
+		suppliers.put( "PWD", this::getCurrentContextPath );
+		suppliers.put( "RTI_HOME", this::getRtiHome );
+		suppliers.put( "RTI_NAME", ()-> PorticoConstants.RTI_NAME );
+		suppliers.put( "RTI_RID_FILE", this::getRidFile );
+		suppliers.put( "RTI_VERSION", ()-> PorticoConstants.RTI_VERSION );
+	}
+
+	private String getCurrentContextPath()
+	{
+		return container.getCurrentContext().getHeirachicalName();
+	}
+	
+	private String getRtiHome()
+	{
+		return container.getRti().getRid().getRtiHome().getAbsolutePath();
+	}
+	
+	private String getRidFile()
+	{
+		return container.getRti().getRid().getRidFile().getAbsolutePath();
+	}
+	
+	/**
+	 * Replaces any instances of environment variable tokens in the provided string with their
+	 * corresponding values
+	 * 
+	 * @param commandline the string to replace the environment variable tokens in
+	 * @return a copy of <code>commandline</code>, with any environment variable tokens replaced
+	 */
+	public String replaceTokens( String commandline )
+	{
+		String newCommandline = commandline;
+		for( Entry<String,Supplier<String>> entry : this.suppliers.entrySet() )
+		{
+			String query = "$" + entry.getKey();
+			newCommandline = newCommandline.replace( query, entry.getValue().get() );
+		}
+		
+		return newCommandline;
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+	/**
+	 * Returns the value of the specified environment variable
+	 * 
+	 * @param key the name of the environment variable
+	 * @return the value of the environment variable
+	 */
+	public String get( String key )
+	{
+		String value = null;
+		Supplier<String> supplier = this.suppliers.get( key );
+		if( supplier != null )
+			value = supplier.get();
+		
+		return value;
+	}
+
+	/**
+	 * @return all environment variable keys that are registered
+	 */
+	public Set<String> getKeys()
+	{
+		return this.suppliers.keySet();
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/portico/org/portico2/rti/cli/RtiCli.java
+++ b/codebase/src/java/portico/org/portico2/rti/cli/RtiCli.java
@@ -14,8 +14,17 @@
  */
 package org.portico2.rti.cli;
 
+import java.util.StringTokenizer;
+
 import org.portico2.common.utils.TextDevice;
 import org.portico2.rti.RTI;
+import org.portico2.rti.cli.command.CommandFactory;
+import org.portico2.rti.cli.command.ICommand;
+import org.portico2.rti.cli.fs.FSContext;
+import org.portico2.rti.cli.fs.FSContextFactory;
+import org.portico2.rti.cli.fs.FSContext.ContextType;
+import org.portico2.rti.federation.Federation;
+import org.portico2.rti.federation.FederationManager;
 
 /**
  * This class provides a basic command line interface to control an RTI instance.
@@ -30,25 +39,31 @@ public class RtiCli implements Runnable
 	//                   INSTANCE VARIABLES
 	//----------------------------------------------------------
 	private RTI rti;
+	private EnvironmentVariables env;
 	private TextDevice console;
+	private FSContext rootContext;
+	private FSContext currentContext;
+	private volatile boolean shutdownFlag;
 	
 	private Thread thread;
 
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
 	//----------------------------------------------------------
-	//public CommandInterpreter( RTI rti, Reader reader /*wrap in buffered reader*/ )
 	public RtiCli( RTI rti )
 	{
 		this.rti = rti;
+		this.env = new EnvironmentVariables( this );
 		this.console = TextDevice.getDefaultDevice();
+		this.rootContext = FSContextFactory.createRootContext();
+		this.currentContext = this.rootContext;
+		this.shutdownFlag = false;
 		this.thread = null; // set in start()
 	}
 
 	//----------------------------------------------------------
 	//                    INSTANCE METHODS
 	//----------------------------------------------------------
-
 	public void start()
 	{
 		if( this.thread != null )
@@ -58,39 +73,135 @@ public class RtiCli implements Runnable
 		this.thread.start();
 	}
 	
+	@Override
 	public void run()
 	{
-		if( this.console == null )
-			;
-		
 		while( Thread.interrupted() == false )
 		{
-			String command = console.readLine( "rti> " );
-			process( command );
+			String commandline = console.readLine( getCommandPrompt() );
+			try
+			{
+				process( commandline );
+			}
+			catch( Exception e )
+			{
+				console.printf( "[Error] (%s) %s\n", e.getClass().getSimpleName(), e.getMessage() );
+			}
+			
+			if( this.shutdownFlag )
+			{
+				rti.shutdown();
+				Thread.currentThread().interrupt();
+			}
+			else
+			{
+				console.printf( "\n" );
+			}
 		}
 	}
 	
+	private String getCommandPrompt()
+	{
+		String host = "rti";
+		String context = currentContext == rootContext ? "/" : currentContext.getHeirachicalName();
+		String prompt = ">";
+		return host + " " + context + prompt + " ";
+	}
+	
+	/**
+	 * Flags the CLI for shutdown.
+	 * <p/>
+	 * Once flagged for shutdown, Portico will cleanly terminate at the end of the next run() cycle
+	 */
+	public void flagShutdown()
+	{
+		this.shutdownFlag = true;
+	}
+	
+	public boolean isValidContext( FSContext candidate )
+	{
+		ContextType theType = candidate.getType();
+		if( theType == ContextType.RTI )
+			return true;
+
+		boolean valid = false;
+		FederationManager fedman = rti.getFederationManager();
+		if( theType == ContextType.Federation )
+		{
+			valid = fedman.containsFederation( candidate.getName() );
+		}
+		else if( theType == ContextType.Federate )
+		{
+			String federationName = candidate.getParent().getName();
+			Federation federation = fedman.getFederation( federationName );
+			if( federation != null )
+				valid = federation.containsFederate( candidate.getName() );
+		}
+		
+		return valid;
+	}
 	
 	////////////////////////////////////////////////////////////////////////////////////////
 	///  Command Processing   //////////////////////////////////////////////////////////////
 	////////////////////////////////////////////////////////////////////////////////////////
-	private void process( String command )
+	private void process( String commandline )
 	{
-		if( command == null || command.trim().equals("") )
+		if( commandline.isEmpty() )
 			return;
-
-		command = command.trim().toLowerCase();
-		if( command.equals("quit") || command.equals("exit") )
-		{
-			rti.shutdown();
-			Thread.currentThread().interrupt();
-		}
-		else
-		{
-			this.console.printf( "command not known: %s\n", command );
-		}
+		
+		// Replace any environment variable tokens with their corresponding values
+		commandline = env.replaceTokens( commandline );
+		
+		// Tokenise the command line string
+		StringTokenizer tok = new StringTokenizer( commandline );
+		
+		// Get the first token (the actual command) and generate a command object from it
+		String command = tok.nextToken();
+		ICommand commandImpl = CommandFactory.create( command );
+		
+		// Merge the rest of the arguments into a String array
+		int remainingTokens = tok.countTokens();
+		String[] args = new String[remainingTokens];
+		
+		for( int x = 0 ; x < remainingTokens ; ++x )
+			args[x] = tok.nextToken();
+		
+		// Execute the command
+		commandImpl.execute( this, args );
 	}
-
+	
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+	public RTI getRti()
+	{
+		return this.rti;
+	}
+	
+	public EnvironmentVariables getEnvironmentVariables()
+	{
+		return this.env;
+	}
+	
+	public FSContext getRootContext()
+	{
+		return this.rootContext;
+	}
+	
+	public FSContext getCurrentContext()
+	{
+		return this.currentContext;
+	}
+	
+	public void setCurrentContext( FSContext context )
+	{
+		this.currentContext = context;
+	}
+	
+	public TextDevice getConsole()
+	{
+		return this.console;
+	}
 	
 	//----------------------------------------------------------
 	//                     STATIC METHODS

--- a/codebase/src/java/portico/org/portico2/rti/cli/command/ChangeContext.java
+++ b/codebase/src/java/portico/org/portico2/rti/cli/command/ChangeContext.java
@@ -1,0 +1,81 @@
+/*
+ *   Copyright 2018 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.rti.cli.command;
+
+import org.portico2.rti.RTI;
+import org.portico2.rti.cli.RtiCli;
+import org.portico2.rti.cli.fs.FSContext;
+import org.portico2.rti.cli.fs.FSContextFactory;
+
+/**
+ * Changes the CLI context to point to another place in the pseudo file system
+ * <p/>
+ * <b>Expected Usage:</b> cd newcontext
+ */
+public class ChangeContext implements ICommand
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	public void execute( RtiCli container, String... args )
+	{
+		RTI rti = container.getRti();
+		
+		// Make sure there is always 1 argument
+		if( args.length != 1 )
+		{
+			// if there were an incorrect number of arguments, throw an exception
+			throw new IllegalArgumentException( "Incorrect number of arguments." +
+			                                    " Expected usage: cd pathname");
+		}
+		
+		// Build up the context to where the user wants to go
+		FSContext destination = FSContextFactory.fromPath( container, args[0] );
+		
+		// Check if the destination context is valid
+		if( container.isValidContext(destination) )
+		{
+			// if it is, set the current context to the destination context
+			container.setCurrentContext( destination );
+		}
+		else
+		{
+			// otherwise, throw an exception
+			throw new IllegalArgumentException("Path does not exist: " + destination.getHeirachicalName() );
+		}
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+	
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/portico/org/portico2/rti/cli/command/CommandFactory.java
+++ b/codebase/src/java/portico/org/portico2/rti/cli/command/CommandFactory.java
@@ -1,0 +1,73 @@
+/*
+ *   Copyright 2018 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.rti.cli.command;
+
+/**
+ * Quick and dirty command factory, that creates {@link ICommand} instances based on a command name
+ */
+public class CommandFactory
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	public static ICommand create( String command )
+	{
+		if( command.equals("cd") )
+			return new ChangeContext();
+		else if( command.equals("echo") )
+			return new Echo();
+		else if( command.equals("env") )
+			return new ListEnvironmentVariables();
+		else if( command.equals("exit") )
+			return new Shutdown();
+		else if( command.equals("ls") )
+			return new ListContextContents();
+		else if( command.equals("mkfederation") )
+			return new CreateFederation();
+		else if( command.equals("mominfo") )
+			return new MomInfo();
+		else if( command.equals("pubs") )
+			return new PubInfo();
+		else if( command.equals("rtiinfo") )
+			return new RtiInfo();
+		else if( command.equals("rm") )
+			return new RemoveContext();
+		else if( command.equals("subs") )
+			return new SubInfo();
+		else
+			throw new IllegalArgumentException( "Unknown command: " + command );
+	}
+}

--- a/codebase/src/java/portico/org/portico2/rti/cli/command/CreateFederation.java
+++ b/codebase/src/java/portico/org/portico2/rti/cli/command/CreateFederation.java
@@ -1,0 +1,102 @@
+/*
+ *   Copyright 2018 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.rti.cli.command;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.portico.lrc.model.ObjectModel;
+import org.portico.utils.fom.FomParser;
+import org.portico2.common.messaging.MessageContext;
+import org.portico2.rti.cli.RtiCli;
+import org.portico2.rti.services.mom.data.FomModule;
+
+/**
+ * Creates a new federation given a provided name and fed file
+ * <p/>
+ * <b>Expected Usage:</b> mkfederation name fedfile
+ */
+public class CreateFederation implements ICommand
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	public void execute( RtiCli container, String... args )
+	{
+		if( args.length != 2 )
+		{
+			// if there were an incorrect number of arguments, throw an exception
+			throw new IllegalArgumentException( "Incorrect number of arguments." +
+			                                    " Expected usage: mkfederation name fedfile");
+		}
+		
+		String name = args[0];
+		String fed = args[1];
+		
+		File fedFile = new File( fed );
+		URL fedUrl = null;
+		try
+		{
+			fedUrl = fedFile.toURI().toURL();
+		}
+		catch( MalformedURLException mue )
+		{
+			throw new IllegalArgumentException( mue );
+		}
+		
+		ObjectModel fom = FomParser.parse( fedUrl );
+		ObjectModel.mommify( fom );
+		ObjectModel.resolveSymbols( fom );
+		
+		org.portico2.common.services.federation.msg.CreateFederation create = 
+			new org.portico2.common.services.federation.msg.CreateFederation();
+		List<FomModule> rawModules = new ArrayList<>();
+		rawModules.add( new FomModule(fedUrl) );
+		
+		create.setFederationName( name );
+		create.setModel( fom, rawModules );
+		create.setHlaVersion( fom.getHlaVersion() );
+		
+		MessageContext context = new MessageContext( create );
+		container.getRti().getInbox().receiveControlMessage( context, null );
+		
+		if( context.isErrorResponse() )
+			throw context.getErrorResponseException();
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/portico/org/portico2/rti/cli/command/Echo.java
+++ b/codebase/src/java/portico/org/portico2/rti/cli/command/Echo.java
@@ -1,0 +1,63 @@
+/*
+ *   Copyright 2018 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.rti.cli.command;
+
+import org.portico2.common.utils.TextDevice;
+import org.portico2.rti.cli.RtiCli;
+
+/**
+ * Echos the provided arguments to the CLI's text device
+ * <p/>
+ * <b>Expected Usage:</b> echo content
+ */
+public class Echo implements ICommand
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	public void execute( RtiCli container, String... args )
+	{
+		TextDevice console = container.getConsole();
+		StringBuilder builder = new StringBuilder();
+		for( String arg : args )
+		{
+			builder.append( arg );
+			builder.append( " " );
+		}
+		console.printf( "%s\n", builder.toString() );
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+	
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/portico/org/portico2/rti/cli/command/ICommand.java
+++ b/codebase/src/java/portico/org/portico2/rti/cli/command/ICommand.java
@@ -1,0 +1,39 @@
+/*
+ *   Copyright 2018 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.rti.cli.command;
+
+import org.portico2.rti.cli.RtiCli;
+
+/**
+ * A command that can be executed by the {@link RtiCli}
+ */
+public interface ICommand
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	/**
+	 * Executes a command in the {@link RtiCli} container
+	 * 
+	 * @param container the {@link RtiCli} that the command is to be run in
+	 * @param args the arguments to the command
+	 */
+	public void execute( RtiCli container, String... args );
+
+}

--- a/codebase/src/java/portico/org/portico2/rti/cli/command/ListContextContents.java
+++ b/codebase/src/java/portico/org/portico2/rti/cli/command/ListContextContents.java
@@ -1,0 +1,121 @@
+/*
+ *   Copyright 2018 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.rti.cli.command;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.portico2.rti.RTI;
+import org.portico2.rti.cli.RtiCli;
+import org.portico2.rti.cli.fs.FSContext;
+import org.portico2.rti.cli.fs.FSContext.ContextType;
+import org.portico2.rti.cli.fs.FSContextFactory;
+import org.portico2.rti.federation.Federate;
+import org.portico2.rti.federation.Federation;
+import org.portico2.rti.federation.FederationManager;
+
+/**
+ * Lists the contents of a {@link FSContext} node.
+ * <p/>
+ * If no context argument is provided, the current context is used 
+ * <p/>
+ * <b>Expected Usage:</b> ls [context]
+ */
+public class ListContextContents implements ICommand
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	public void execute( RtiCli container, String... args )
+	{
+		RTI rti = container.getRti();
+		FSContext context = container.getCurrentContext();
+		if( args.length > 0 )
+			context = FSContextFactory.fromPath( container, args[0] );
+		
+		if( !container.isValidContext(context) )
+			throw new IllegalArgumentException( "Path does not exist: " + FSContext.getContextPath(context) );
+			
+		
+		List<String> names = new ArrayList<>();
+		names.add( "./" );
+		names.add( "../" );
+		if( context.getType() == ContextType.RTI )
+		{
+			names.addAll( getFederationNames(rti) );
+		}
+		else if( context.getType() == ContextType.Federation )
+		{
+			String federationName = context.getName();
+			names.addAll( getFederateNames(rti, federationName) );
+		}
+		
+		for( String name : names )
+			container.getConsole().printf( "%s\n", name );
+	}
+
+	private List<String> getFederationNames( RTI rti )
+	{
+		FederationManager fedman = rti.getFederationManager();
+		Collection<Federation> federations = fedman.getActiveFederations();
+		List<String> names = new ArrayList<>();
+		for( Federation federation : federations )
+			names.add( federation.getFederationName() + "/" );
+		
+		Collections.sort( names );
+		return names;
+	}
+	
+	private List<String> getFederateNames( RTI rti, String federation )
+	{
+		FederationManager fedman = rti.getFederationManager();
+		Federation rtiFederation = fedman.getFederation( federation );
+		if( rtiFederation == null )
+			throw new IllegalArgumentException( "Federation does not exist: " + federation );
+			
+		List<String> names = new ArrayList<>();
+		Set<Federate> federates = rtiFederation.getFederates();
+		for( Federate federate : federates )
+			names.add( federate.getFederateName() );
+		
+		Collections.sort( names );
+		return names;
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+	
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/portico/org/portico2/rti/cli/command/ListEnvironmentVariables.java
+++ b/codebase/src/java/portico/org/portico2/rti/cli/command/ListEnvironmentVariables.java
@@ -1,0 +1,64 @@
+/*
+ *   Copyright 2018 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.rti.cli.command;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.portico2.common.utils.TextDevice;
+import org.portico2.rti.cli.EnvironmentVariables;
+import org.portico2.rti.cli.RtiCli;
+
+/**
+ * Lists the CLI's environment variables
+ */
+public class ListEnvironmentVariables implements ICommand
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	public void execute( RtiCli container, String... args )
+	{
+		TextDevice console = container.getConsole();
+		EnvironmentVariables env = container.getEnvironmentVariables();
+		List<String> keys = new ArrayList<>( env.getKeys() );
+		Collections.sort( keys );
+		for( String envvar : keys )
+			console.printf( "%s=%s\n", envvar, env.get(envvar) );
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+	
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/portico/org/portico2/rti/cli/command/MomInfo.java
+++ b/codebase/src/java/portico/org/portico2/rti/cli/command/MomInfo.java
@@ -1,0 +1,186 @@
+/*
+ *   Copyright 2018 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.rti.cli.command;
+
+import java.util.List;
+
+import org.portico2.common.services.time.data.TimeStatus;
+import org.portico2.common.utils.TextDevice;
+import org.portico2.rti.RTI;
+import org.portico2.rti.cli.RtiCli;
+import org.portico2.rti.cli.fs.FSContext;
+import org.portico2.rti.cli.fs.FSContextFactory;
+import org.portico2.rti.federation.Federate;
+import org.portico2.rti.federation.FederateMetrics;
+import org.portico2.rti.federation.Federation;
+import org.portico2.rti.services.mom.data.FomModule;
+
+/**
+ * Lists MOM information about a federation or federate {@link FSContext}.
+ * <p/>
+ * If no context argument is provided, the current context is used
+ * <p/>
+ * <b>Expected Usage:</b> mominfo [context]
+ */
+public class MomInfo implements ICommand
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	public void execute( RtiCli container, String... args )
+	{
+		RTI rti = container.getRti();
+		FSContext target = container.getCurrentContext();
+		if( args.length > 0 )
+			target = FSContextFactory.fromPath( container, args[0] );
+
+		if( !container.isValidContext(target) )
+			throw new IllegalArgumentException("Path does not exist: " + FSContext.getContextPath(target) );
+		
+		switch( target.getType() )
+		{
+			case Federation:
+				printFederationStatus( container, target );
+				break;
+			case Federate:
+				printFederateStatus( container, target );
+				break;
+			default:
+				throw new IllegalArgumentException("Path: " + FSContext.getContextPath(target) + " is not a federation or a federate.");
+		}
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+	private void printFederationStatus( RtiCli container, FSContext context )
+	{
+		RTI rti = container.getRti(); 
+		Federation federation = rti.getFederationManager().getFederation( context.getName() );
+		if( federation == null )
+		{
+			String contextName = context.getHeirachicalName();
+			if( contextName.isEmpty() )
+				contextName = "/";
+			throw new IllegalArgumentException( FSContext.getContextPath(context) + " is not a federation" );
+		}
+	
+		List<FomModule> modules = federation.getRawFomModules();
+		int moduleCount = modules.size();
+		String[] designators = new String[moduleCount];
+		for( int i = 0 ; i < moduleCount ; ++i )
+			designators[i] = modules.get( i ).getDesignator();
+		String designatorList = String.join( ",", designators );
+		
+		// All the MOM properties that we support for the federation
+		TextDevice console = container.getConsole();
+		paddedPrintln( console, "HLAfederationName:", federation.getFederationName() );
+		paddedPrintln( console, "HLAfederatesInFederation:", federation.getFederates().size() );
+		paddedPrintln( console, "HLAFOMmoduleDesignatorList:", designatorList );
+		paddedPrintln( console, "HLARTIversion:", container.getEnvironmentVariables().get("RTI_VERSION") );
+	}
+	
+	private void printFederateStatus( RtiCli container, FSContext context )
+	{
+		RTI rti = container.getRti(); 
+		Federation federation = rti.getFederationManager().getFederation( context.getParent().getName() );
+		if( federation == null )
+			throw new IllegalArgumentException( FSContext.getContextPath(context.getParent()) + " is not a federation" );
+		
+		Federate federate = federation.getFederate( context.getName() );
+		if( federate == null )
+			throw new IllegalArgumentException( FSContext.getContextPath(context) + " is not a federate" );
+		
+		List<FomModule> modules = federate.getRawFomModules();
+		int moduleCount = modules.size();
+		String[] designators = new String[moduleCount];
+		for( int i = 0 ; i < moduleCount ; ++i )
+			designators[i] = modules.get( i ).getDesignator();
+		String designatorList = String.join( ",", designators );
+		
+		// All the MOM properties that we support for the federate
+		TextDevice console = container.getConsole();
+		TimeStatus time = federation.getTimeManager().getTimeStatus( federate.getFederateHandle() );
+		FederateMetrics metrics = federate.getMetrics();
+		
+		paddedPrintln( console, "HLAfederateHandle:", federate.getFederateHandle() );
+		paddedPrintln( console, "HLAfederateName:", federate.getFederateName() );
+		paddedPrintln( console, "HLARTIversion:", container.getEnvironmentVariables().get("RTI_VERSION") );
+		paddedPrintln( console, "HLAFOMmoduleDesignatorList:", designatorList );
+		paddedPrintln( console, "HLAtimeConstrained:", time.isConstrained() );
+		paddedPrintln( console, "HLAtimeRegulating:", time.isRegulating() );
+		paddedPrintln( console, "HLAasynchronousDelivery:", time.isAsynchronous() );
+		//paddedPrintln( console, "HLAfederateState:", );
+		//paddedPrintln( console, "HLAtimeManagerState:", );
+		paddedPrintln( console, "HLAlogicalTime:", time.currentTime );
+		paddedPrintln( console, "HLAlookahead:", time.lookahead );
+		paddedPrintln( console, "HLALBTS:", time.lbts );
+		//paddedPrintln( console, "HLAGALT:", );
+		//paddedPrintln( console, "HLALITS:", );
+		//paddedPrintln( console, "HLAROlength:", );
+		//paddedPrintln( console, "HLATSOlength:", );
+		paddedPrintln( console, "HLAreflectionsReceived:", metrics.getTotalReflectionsReceived() );
+		paddedPrintln( console, "HLAupdatesSent:", metrics.getTotalUpdatesSent() );
+		paddedPrintln( console, "HLAinteractionsReceived:", metrics.getTotalInteractionsReceived() );
+		paddedPrintln( console, "HLAinteractionsSent:", metrics.getTotalInteractionsSent() );
+		paddedPrintln( console, "HLAobjectInstancesThatCanBeDeleted:", metrics.getObjectsOwned().size() );
+		paddedPrintln( console, "HLAobjectInstancesUpdated:", metrics.getTotalObjectInstancesUpdated() );
+		paddedPrintln( console, "HLAobjectInstancesReflected:", metrics.getTotalObjectInstancesReflected() );
+		paddedPrintln( console, "HLAobjectInstancesDeleted:", metrics.getObjectsDeleted() );
+		paddedPrintln( console, "HLAobjectInstancesRemoved:", metrics.getObjectsRemoved() );
+		paddedPrintln( console, "HLAobjectInstancesRegistered:", metrics.getObjectsRegistered() );
+		paddedPrintln( console, "HLAobjectInstancesDiscovered:", metrics.getObjectsDiscovered() );
+		paddedPrintln( console, "HLAtimeGrantedTime:", time.getCurrentTime() );
+		paddedPrintln( console, "HLAtimeAdvancingTime:", time.getRequestedTime() );
+		
+	}
+	
+	private void paddedPrintln( TextDevice console, String key, String value )
+	{
+		console.printf( "%-36s%s\n", key, value );
+	}
+	
+	private void paddedPrintln( TextDevice console, String key, boolean value )
+	{
+		console.printf( "%-36s%s\n", key, value ? "true" : "false" );
+	}
+	
+	private void paddedPrintln( TextDevice console, String key, int value )
+	{
+		console.printf( "%-36s%d\n", key, value );
+	}
+	
+	private void paddedPrintln( TextDevice console, String key, double value )
+	{
+		console.printf( "%-36s%f\n", key, value );
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/portico/org/portico2/rti/cli/command/PubInfo.java
+++ b/codebase/src/java/portico/org/portico2/rti/cli/command/PubInfo.java
@@ -1,0 +1,122 @@
+/*
+ *   Copyright 2018 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.rti.cli.command;
+
+import java.util.Set;
+
+import org.portico.lrc.model.ACMetadata;
+import org.portico.lrc.model.ICMetadata;
+import org.portico.lrc.model.OCMetadata;
+import org.portico.lrc.model.ObjectModel;
+import org.portico2.common.services.pubsub.data.InterestManager;
+import org.portico2.common.utils.TextDevice;
+import org.portico2.rti.RTI;
+import org.portico2.rti.cli.RtiCli;
+import org.portico2.rti.cli.fs.FSContext;
+import org.portico2.rti.cli.fs.FSContextFactory;
+import org.portico2.rti.federation.Federate;
+import org.portico2.rti.federation.Federation;
+
+/**
+ * Lists a federate's object and interaction publication information
+ * <p/>
+ * If no context argument is provided, the current context is used
+ * <p/>
+ * <b>Expected Usage:</b> pubs [context]
+ */
+public class PubInfo implements ICommand
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	public void execute( RtiCli container, String... args )
+	{
+		RTI rti = container.getRti();
+		FSContext target = container.getCurrentContext();
+		if( args.length > 0 )
+			target = FSContextFactory.fromPath( container, args[0] );
+
+		if( !container.isValidContext(target) )
+			throw new IllegalArgumentException("Path does not exist: " + FSContext.getContextPath(target) );
+		
+		switch( target.getType() )
+		{
+			case Federate:
+				printPublications( container, target );
+				break;
+			default:
+				throw new IllegalArgumentException("Path: " + FSContext.getContextPath(target) + " is not a federate.");
+		}
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+	private void printPublications( RtiCli container, FSContext context )
+	{
+		RTI rti = container.getRti();
+		TextDevice console = container.getConsole();
+		
+		Federation federation = rti.getFederationManager().getFederation( context.getParent().getName() );
+		if( federation == null )
+			throw new IllegalArgumentException( FSContext.getContextPath(context.getParent()) + " is not a federation" );
+	
+		Federate federate = federation.getFederate( context.getName() );
+		if( federate == null )
+			throw new IllegalArgumentException( FSContext.getContextPath(context) + " is not a federate" );
+		
+		ObjectModel fom = federation.getFOM();
+		int federateHandle = federate.getFederateHandle();
+		InterestManager interests = federation.getInterestManager();
+		
+		Set<Integer> objectClasses = interests.getAllPublishedObjectClasses( federateHandle );
+		for( int ocHandle : objectClasses )
+		{
+			OCMetadata oc = fom.getObjectClass( ocHandle );
+			console.printf( "%s (%d)\n", oc.getQualifiedName(), ocHandle );
+			Set<Integer> attHandles = interests.getPublishedAttributes( federateHandle, ocHandle );
+			for( int attHandle : attHandles )
+			{
+				ACMetadata ac = oc.getAttribute( attHandle );
+				console.printf( "\t%s (%d)\n", ac.getName(), attHandle );
+			}
+		}
+		
+		Set<Integer> interactionClasses = interests.getAllPublishedInteractionClasses( federateHandle );
+		for( int icHandle : interactionClasses )
+		{
+			ICMetadata ic = fom.getInteractionClass( icHandle );
+			console.printf( "%s (%d)\n", ic.getQualifiedName(), icHandle );
+		}
+	}
+	
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/portico/org/portico2/rti/cli/command/RemoveContext.java
+++ b/codebase/src/java/portico/org/portico2/rti/cli/command/RemoveContext.java
@@ -1,0 +1,126 @@
+/*
+ *   Copyright 2018 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.rti.cli.command;
+
+import org.portico.lrc.compat.JResignAction;
+import org.portico2.common.messaging.MessageContext;
+import org.portico2.common.services.federation.msg.DestroyFederation;
+import org.portico2.common.services.federation.msg.ResignFederation;
+import org.portico2.rti.RTI;
+import org.portico2.rti.cli.RtiCli;
+import org.portico2.rti.cli.fs.FSContext;
+import org.portico2.rti.cli.fs.FSContextFactory;
+import org.portico2.rti.federation.Federate;
+import org.portico2.rti.federation.Federation;
+
+/**
+ * Removes a federation or federate, depending on the context provided
+ * <p/>
+ * If a federate context is provided, then the RTI will resign the federate from the federation
+ * <p/>
+ * If a federation context is provided, then the RTI will attempt to destory the federation, which must
+ * be empty.
+ * <p/>
+ * <b>Expected usage:</b> rm context
+ */
+public class RemoveContext implements ICommand
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	public void execute( RtiCli container, String... args )
+	{
+		RTI rti = container.getRti();
+		FSContext context = container.getCurrentContext();
+		if( args.length > 0 )
+			context = FSContextFactory.fromPath( container, args[0] );
+		
+		if( !container.isValidContext(context) )
+			throw new IllegalArgumentException( "Path does not exist: " + FSContext.getContextPath(context) );
+			
+		switch( context.getType() )
+		{
+			case Federation:
+				removeFederation( container, context );
+				break;
+			case Federate:
+				removeFederate( container, context );
+				break;
+			default:
+				throw new IllegalArgumentException( FSContext.getContextPath(context) + " is read only" );
+		}
+	}
+
+	private void removeFederation( RtiCli container, FSContext context )
+	{
+		RTI rti = container.getRti();
+		Federation federation = rti.getFederationManager().getFederation( context.getName() );
+		if( federation == null )
+			throw new IllegalArgumentException( FSContext.getContextPath(context) + " is not a federation" );
+		
+		DestroyFederation destroy = new DestroyFederation( federation.getFederationName() );
+		MessageContext msgContext = new MessageContext( destroy );
+		rti.getInbox().receiveControlMessage( msgContext, null );
+		
+		if( msgContext.isErrorResponse() )
+			throw msgContext.getErrorResponseException();
+	}
+	
+	private void removeFederate( RtiCli container, FSContext context )
+	{
+		RTI rti = container.getRti();
+		Federation federation = rti.getFederationManager().getFederation( context.getParent().getName() );
+		if( federation == null )
+			throw new IllegalArgumentException( FSContext.getContextPath(context.getParent()) + " is not a federation" );
+		
+		Federate federate = federation.getFederate( context.getName() );
+		if( federate == null )
+			throw new IllegalArgumentException( FSContext.getContextPath(context) + " is not a federate" );
+		
+		ResignFederation resign = new ResignFederation( JResignAction.DELETE_OBJECTS_AND_RELEASE_ATTRIBUTES );
+		resign.setFederateName( federate.getFederateName() );
+		resign.setSourceFederate( federation.getFederationHandle() );
+		resign.setFederationName( federation.getFederationName() );
+		resign.setTargetFederation( federation.getFederationHandle() );
+		
+		MessageContext msgContext = new MessageContext( resign );
+		rti.getInbox().receiveControlMessage( msgContext, null );
+		
+		if( msgContext.isErrorResponse() )
+			throw msgContext.getErrorResponseException();
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/portico/org/portico2/rti/cli/command/RtiInfo.java
+++ b/codebase/src/java/portico/org/portico2/rti/cli/command/RtiInfo.java
@@ -1,0 +1,62 @@
+/*
+ *   Copyright 2018 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.rti.cli.command;
+
+import org.portico2.common.utils.TextDevice;
+import org.portico2.rti.RTI;
+import org.portico2.rti.cli.RtiCli;
+
+/**
+ * Lists RTI information
+ */
+public class RtiInfo implements ICommand
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	public void execute( RtiCli container, String... args )
+	{
+		printRtiStatus( container );
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+	private void printRtiStatus( RtiCli container )
+	{
+		TextDevice console = container.getConsole();
+		RTI rti = container.getRti();
+		String connections = String.join( ", ", rti.getConnectionManager().getConnectionDescriptions() );
+		console.printf( "%-16s%s\n", "Version:", container.getEnvironmentVariables().get("RTI_VERSION") );
+		console.printf( "%-16s%s\n", "Connections:", connections );
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/portico/org/portico2/rti/cli/command/Shutdown.java
+++ b/codebase/src/java/portico/org/portico2/rti/cli/command/Shutdown.java
@@ -1,0 +1,53 @@
+/*
+ *   Copyright 2018 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.rti.cli.command;
+
+import org.portico2.rti.cli.RtiCli;
+
+/**
+ * Flags the RTI for shutdown
+ */
+public class Shutdown implements ICommand
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	public void execute( RtiCli container, String... args )
+	{
+		container.flagShutdown();
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+	
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/portico/org/portico2/rti/cli/command/SubInfo.java
+++ b/codebase/src/java/portico/org/portico2/rti/cli/command/SubInfo.java
@@ -1,0 +1,122 @@
+/*
+ *   Copyright 2018 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.rti.cli.command;
+
+import java.util.Set;
+
+import org.portico.lrc.model.ACMetadata;
+import org.portico.lrc.model.ICMetadata;
+import org.portico.lrc.model.OCMetadata;
+import org.portico.lrc.model.ObjectModel;
+import org.portico2.common.services.pubsub.data.InterestManager;
+import org.portico2.common.utils.TextDevice;
+import org.portico2.rti.RTI;
+import org.portico2.rti.cli.RtiCli;
+import org.portico2.rti.cli.fs.FSContext;
+import org.portico2.rti.cli.fs.FSContextFactory;
+import org.portico2.rti.federation.Federate;
+import org.portico2.rti.federation.Federation;
+
+/**
+ * Lists a federate's object and interaction subscription information
+ * <p/>
+ * If no context argument is provided, the current context is used
+ * <p/>
+ * <b>Expected Usage:</b> pubs [context]
+ */
+public class SubInfo implements ICommand
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	public void execute( RtiCli container, String... args )
+	{
+		RTI rti = container.getRti();
+		FSContext target = container.getCurrentContext();
+		if( args.length > 0 )
+			target = FSContextFactory.fromPath( container, args[0] );
+
+		if( !container.isValidContext(target) )
+			throw new IllegalArgumentException("Path does not exist: " + FSContext.getContextPath(target) );
+		
+		switch( target.getType() )
+		{
+			case Federate:
+				printPublications( container, target );
+				break;
+			default:
+				throw new IllegalArgumentException("Path: " + FSContext.getContextPath(target) + " is not a federate.");
+		}
+	}
+	
+	////////////////////////////////////////////////////////////////////////////////////////
+	///  Accessors and Mutators   //////////////////////////////////////////////////////////
+	////////////////////////////////////////////////////////////////////////////////////////
+	private void printPublications( RtiCli container, FSContext context )
+	{
+		RTI rti = container.getRti();
+		TextDevice console = container.getConsole();
+		
+		Federation federation = rti.getFederationManager().getFederation( context.getParent().getName() );
+		if( federation == null )
+			throw new IllegalArgumentException( FSContext.getContextPath(context.getParent()) + " is not a federation" );
+	
+		Federate federate = federation.getFederate( context.getName() );
+		if( federate == null )
+			throw new IllegalArgumentException( FSContext.getContextPath(context) + " is not a federate" );
+		
+		ObjectModel fom = federation.getFOM();
+		int federateHandle = federate.getFederateHandle();
+		InterestManager interests = federation.getInterestManager();
+		
+		Set<Integer> objectClasses = interests.getAllSubscribedObjectClasses( federateHandle );
+		for( int ocHandle : objectClasses )
+		{
+			OCMetadata oc = fom.getObjectClass( ocHandle );
+			console.printf( "%s (%d)\n", oc.getQualifiedName(), ocHandle );
+			Set<Integer> attHandles = interests.getSubscribedAttributes( federateHandle, ocHandle );
+			for( int attHandle : attHandles )
+			{
+				ACMetadata ac = oc.getAttribute( attHandle );
+				console.printf( "\t%s (%d)\n", ac.getName(), attHandle );
+			}
+		}
+		
+		Set<Integer> interactionClasses = interests.getAllSubscribedInteractionClasses( federateHandle );
+		for( int icHandle : interactionClasses )
+		{
+			ICMetadata ic = fom.getInteractionClass( icHandle );
+			console.printf( "%s (%d)\n", ic.getQualifiedName(), icHandle );
+		}
+	}
+	
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/portico/org/portico2/rti/cli/fs/FSContext.java
+++ b/codebase/src/java/portico/org/portico2/rti/cli/fs/FSContext.java
@@ -1,0 +1,175 @@
+/*
+ *   Copyright 2018 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.rti.cli.fs;
+
+import java.util.Set;
+
+/**
+ * Represents a node within the RTI pseudo file system 
+ */
+public class FSContext
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+	public static enum ContextType 
+	{
+		RTI, 
+		Federation, 
+		Federate, 
+		None
+	};
+		
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private String name;
+	private ContextType type;
+	private FSContext parent;
+	private Set<String> validFiles;
+	private ContextType childDirType;
+	
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public FSContext( String newName, 
+	                  ContextType newType, 
+	                  FSContext newParent, 
+	                  Set<String> newValidFiles, 
+	                  ContextType newChildType )
+	{
+		this.name = newName;
+		this.type = newType;
+		this.parent = newParent;
+		this.validFiles = newValidFiles;
+		this.childDirType = newChildType;
+	}
+	
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	/**
+	 * @return the value of this context's local name.
+	 */
+	public String getName()
+	{
+		return name;
+	}
+
+
+	/**
+	 * Sets the value of this context's local name.
+	 */
+	public void setName( String name )
+	{
+		this.name = name;
+	}
+
+
+	/**
+	 * @return this context's parent.
+	 */
+	public FSContext getParent()
+	{
+		return parent;
+	}
+
+
+	/**
+	 * Sets this context's parent.
+	 */
+	public void setParent( FSContext parent )
+	{
+		this.parent = parent;
+	}
+
+
+	/**
+	 * @return what context type this context is.
+	 */
+	public ContextType getType()
+	{
+		return type;
+	}
+
+
+	/**
+	 * Sets what context type this context is
+	 */
+	public void setType( ContextType type )
+	{
+		this.type = type;
+	}
+
+	/**
+	 * @return  what type is allowed to reside under this context
+	 */
+	public ContextType getChildDirType()
+	{
+		return childDirType;
+	}
+
+	/**
+	 * Sets what child type this context can have
+	 */
+	public void setChildDirType( ContextType childDirType )
+	{
+		this.childDirType = childDirType;
+	}
+
+	/**
+	 * @return a list of psuedo files that are contained within this context.
+	 */
+	public Set<String> getValidFiles()
+	{
+		return validFiles;
+	}
+
+	/**
+	 * @return the list of psuedo files that are contained within this context.
+	 */
+	public void setValidFiles( Set<String> validFiles )
+	{
+		this.validFiles = validFiles;
+	}	
+	
+	/**
+	 * @return the absoloute path to this context
+	 */
+	public String getHeirachicalName()
+	{
+		if ( this.parent != null )
+		{
+			return this.parent.getHeirachicalName() + "/" + this.getName();
+		}
+		else
+		{
+			return this.name;
+		}
+	}
+	
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	public static String getContextPath( FSContext context )
+	{
+		String contextName = context.getHeirachicalName();
+		if( contextName.isEmpty() )
+			contextName = "/";
+		
+		return contextName;
+	}
+}
+

--- a/codebase/src/java/portico/org/portico2/rti/cli/fs/FSContextFactory.java
+++ b/codebase/src/java/portico/org/portico2/rti/cli/fs/FSContextFactory.java
@@ -1,0 +1,173 @@
+/*
+ *   Copyright 2006 The Portico Project
+ *
+ *   This file is part of portico.
+ *
+ *   portico is free software; you can redistribute it and/or modify
+ *   it under the terms of the Common Developer and Distribution License (CDDL) 
+ *   as published by Sun Microsystems. For more information see the LICENSE file.
+ *   
+ *   Use of this software is strictly AT YOUR OWN RISK!!!
+ *   If something bad happens you do not have permission to come crying to me.
+ *   (that goes for your lawyer as well)
+ *
+ */
+package org.portico2.rti.cli.fs;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+import org.portico2.rti.cli.RtiCli;
+import org.portico2.rti.cli.fs.FSContext.ContextType;
+
+/**
+ * A Factory class to build the context objects required by the RTI pseudo file system
+ */
+public class FSContextFactory
+{
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+	/**
+	 * Creates a root FSContext object, filling in the Context name, type, parent, valid
+	 * file set and child types accordingly
+	 */
+	public static FSContext createRootContext()
+	{
+		Set<String> validFileSet = new HashSet<String>();
+		FSContext newContext = new FSContext( "", 
+		                                      ContextType.RTI,
+		                                      null, 
+		                                      validFileSet, 
+		                                      ContextType.Federation);
+		return newContext;
+	}
+	
+	public static FSContext fromPath( RtiCli container, String path )
+	{
+		// Create a temporary context to hold where we are going to go
+		// initialise it to where we are currently
+		FSContext tempContext = container.getCurrentContext();
+		
+		// If the path started with the root symbol then point the temp context to the
+		// root context
+		if ( path.startsWith( "/" ) )
+			tempContext = container.getRootContext();
+		
+		// Tokenise the path on /
+		StringTokenizer tok = new StringTokenizer( path, "/" );
+		
+		// Iterate through the tokens
+		while( tok.hasMoreTokens() )
+		{
+			String token = tok.nextToken();
+			
+			// If the current entry in the path is to go up one
+			if( token.equals( ".." ) )
+			{
+				// Have a look at the parent of this context
+				FSContext theParent = tempContext.getParent();
+				
+				// if the parent of this context is null
+				if( theParent == null )
+				{
+					// we are at the root so just stay here
+				}
+				else
+				{
+					// otherwise traverse up
+					tempContext = tempContext.getParent();
+				}
+			}
+			else if( token.equals( "." ) )
+			{
+				// stay in the same context
+			}
+			else
+			{
+				// going down a directory
+				tempContext = FSContextFactory.createContext( token, tempContext );
+			}
+		}
+				
+		return tempContext;	
+	}
+	
+	/**
+	 * Creates FSContext objects other than the root object. The type of FSContext object
+	 * created depends on the parent type parsed to the function
+	 */
+	private static FSContext createContext( String name, FSContext parent )
+	{
+		ContextType parentType = parent.getType();
+		
+		if( parentType == FSContext.ContextType.RTI )
+			return createFederationContext( name, parent );
+		else if( parentType == FSContext.ContextType.Federation )
+			return createFederateContext( name, parent );
+		else
+			throw new IllegalArgumentException( "Can't create a context under: " + parentType );
+	}
+	
+	/**
+	 * Creates a Federation FSContext object, filling in the Context name, type, parent, valid
+	 * file set and child types accordingly
+	 */
+	private static FSContext createFederationContext( String name, FSContext parent )
+	{
+		Set<String> validFileSet = new HashSet<String>();
+		ContextType parentType = parent.getType();
+		
+		if( parent.getType() != ContextType.RTI )
+			throw new IllegalArgumentException( "Can't create a federation context under " + parentType );
+		
+		FSContext newContext = new FSContext( name, 
+		                                      ContextType.Federation, 
+		                                      parent, 
+		                                      validFileSet, 
+		                                      ContextType.Federate );
+		
+		return newContext;
+	}
+	
+	/**
+	 * Creates a Federate FSContext object, filling in the Context name, type, parent, valid
+	 * file set and child types accordingly
+	 */
+	private static FSContext createFederateContext( String name, FSContext parent )
+	{
+		Set<String> validFileSet = new HashSet<String>();
+		ContextType parentType = parent.getType();
+		
+		if( parent.getType() != ContextType.Federation )
+			throw new IllegalArgumentException( "Can't create a federate context under " + parentType );
+		
+		FSContext newContext = new FSContext( name, 
+		                                      ContextType.Federate, 
+		                                      parent, 
+		                                      validFileSet, 
+		                                      ContextType.None );
+		
+		return newContext;
+	}
+	
+	
+}
+

--- a/codebase/src/java/portico/org/portico2/rti/federation/Federate.java
+++ b/codebase/src/java/portico/org/portico2/rti/federation/Federate.java
@@ -38,8 +38,6 @@ public class Federate
 	private RtiConnection federateConnection;
 	private FederateMetrics metrics;
 	private List<FomModule> fomModules;
-	
-	private TimeStatus timeStatus;
 
 	//----------------------------------------------------------
 	//                      CONSTRUCTORS
@@ -51,8 +49,6 @@ public class Federate
 		this.metrics = new FederateMetrics();
 		this.federateHandle = PorticoConstants.NULL_HANDLE;
 		this.fomModules = new ArrayList<FomModule>();
-		
-		this.timeStatus = new TimeStatus();
 	}
 
 	//----------------------------------------------------------
@@ -80,11 +76,6 @@ public class Federate
 	public RtiConnection getConnection()
 	{
 		return this.federateConnection;
-	}
-
-	public TimeStatus getTimeStatus()
-	{
-		return this.timeStatus;
 	}
 	
 	public FederateMetrics getMetrics()

--- a/codebase/src/java/portico/org/portico2/rti/federation/FederateMetrics.java
+++ b/codebase/src/java/portico/org/portico2/rti/federation/FederateMetrics.java
@@ -167,6 +167,16 @@ public class FederateMetrics
 		return results;
 	}
 	
+	public int getTotalReflectionsReceived()
+	{
+		ObjectClassBasedCount[] reflections = getReflectionsReceived();
+		int grandTotal = 0;
+		for( ObjectClassBasedCount classCount : reflections )
+			grandTotal += classCount.getCount();
+		
+		return grandTotal;
+	}
+	
 	public ObjectClassBasedCount[] getObjectInstancesReflected()
 	{
 		ObjectClassBasedCount[] results = new ObjectClassBasedCount[this.reflectionsReceived.size()];
@@ -175,6 +185,16 @@ public class FederateMetrics
 			results[index++] = tracker.getTotalUniqueInstances();
 		
 		return results;
+	}
+	
+	public int getTotalObjectInstancesReflected()
+	{
+		ObjectClassBasedCount[] reflected = this.getObjectInstancesReflected();
+		int grandTotal = 0;
+		for( ObjectClassBasedCount classCount : reflected )
+			grandTotal += classCount.getCount();
+		
+		return grandTotal;
 	}
 	
 	/**
@@ -190,6 +210,16 @@ public class FederateMetrics
 		return results;
 	}
 	
+	public int getTotalUpdatesSent()
+	{
+		ObjectClassBasedCount[] updated = this.getUpdatesSent();
+		int grandTotal = 0;
+		for( ObjectClassBasedCount classCount : updated )
+			grandTotal += classCount.getCount();
+		
+		return grandTotal;
+	}
+	
 	/**
 	 * @return the number of times the federate has invoked the UpdateAttributeValues service
 	 */
@@ -201,6 +231,16 @@ public class FederateMetrics
 			results[index++] = tracker.getTotalUniqueInstances();
 		
 		return results;
+	}
+	
+	public int getTotalObjectInstancesUpdated()
+	{
+		ObjectClassBasedCount[] updated = this.getObjectInstancesUpdated();
+		int grandTotal = 0;
+		for( ObjectClassBasedCount classCount : updated )
+			grandTotal += classCount.getCount();
+		
+		return grandTotal;
 	}
 	
 	/**
@@ -217,6 +257,16 @@ public class FederateMetrics
 		return results;
 	}
 	
+	public int getTotalInteractionsReceived()
+	{
+		InteractionCount[] received = this.getInteractionsReceived();
+		int grandTotal = 0;
+		for( InteractionCount classCount : received )
+			grandTotal += classCount.getCount();
+		
+		return grandTotal;
+	}
+	
 	/**
 	 * @return the number of times the federate has invoked the SendInteractions service for each
 	 *         interaction class
@@ -229,6 +279,16 @@ public class FederateMetrics
 			results[index++] = classCount;
 		
 		return results;
+	}
+	
+	public int getTotalInteractionsSent()
+	{
+		InteractionCount[] received = this.getInteractionsSent();
+		int grandTotal = 0;
+		for( InteractionCount classCount : received )
+			grandTotal += classCount.getCount();
+		
+		return grandTotal;
 	}
 	
 	/**

--- a/codebase/src/java/portico/org/portico2/rti/federation/Federation.java
+++ b/codebase/src/java/portico/org/portico2/rti/federation/Federation.java
@@ -345,6 +345,11 @@ public class Federation
 			federateConnections.remove( connection );
 	}
 
+	public Set<Federate> getFederates()
+	{
+		return new HashSet<>( this.federates.values() );
+	}
+	
 	public Federate getFederate( String name )
 	{
 		for( Federate federate: federates.values() )

--- a/codebase/src/java/portico/org/portico2/rti/services/RTIMessageHandler.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/RTIMessageHandler.java
@@ -221,13 +221,14 @@ public abstract class RTIMessageHandler implements IMessageHandler
 	{
 		Federate sender = federation.getFederate( senderHandle );
 		message.setSourceFederate( senderHandle );
-
+		
+		
 		// only set the time if it hasn't already been set AND the federate is regulating
 		if( (message.getTimestamp() == PorticoConstants.NULL_TIME) &&
-			sender.getTimeStatus().isRegulating() &&
+			timeManager.isRegulating( senderHandle ) &&
 			message.isSpecDefinedMessage() )
 		{
-			message.setTimestamp( sender.getTimeStatus().getCurrentTime() );
+			message.setTimestamp( timeManager.getCurrentTime(senderHandle) );
 		}
 		
 		return message;

--- a/codebase/src/java/portico/org/portico2/rti/services/RTIMessageHandler.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/RTIMessageHandler.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import org.apache.logging.log4j.Logger;
 import org.portico.lrc.compat.JConfigurationException;
 import org.portico.lrc.compat.JException;
+import org.portico.lrc.compat.JFederateNotExecutionMember;
 import org.portico.lrc.model.ACInstance;
 import org.portico.lrc.model.OCInstance;
 import org.portico.lrc.model.OCMetadata;
@@ -612,7 +613,15 @@ public abstract class RTIMessageHandler implements IMessageHandler
 		return dimensionHandle+" <unknown>";
 	}
 
-
+	/**
+	 * Checks whether the federate is a member of the context federation, and if not throws a 
+	 * {@link JFederateNotExecutionMember} exception 
+	 */
+	protected void checkIsMember( int federate ) throws JFederateNotExecutionMember
+	{
+		if( !federation.containsFederate( federate ) )
+			throw new JFederateNotExecutionMember();
+	}
 	//----------------------------------------------------------
 	//                     STATIC METHODS
 	//----------------------------------------------------------

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomFederate.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomFederate.java
@@ -31,9 +31,11 @@ import org.portico.lrc.model.Mom;
 import org.portico.lrc.model.OCInstance;
 import org.portico.lrc.model.datatype.IDatatype;
 import org.portico2.common.services.object.msg.UpdateAttributes;
+import org.portico2.common.services.time.data.TimeStatus;
 import org.portico2.rti.federation.Federate;
 import org.portico2.rti.services.object.data.RACInstance;
 import org.portico2.rti.services.object.data.ROCInstance;
+import org.portico2.rti.services.time.data.TimeManager;
 
 /**
  * Contains links between the {@link OCInstance} used to represent the federate in the federation
@@ -54,6 +56,7 @@ public class MomFederate
 	private Federate federate;
 	private Logger momLogger;
 	private HLAVersion version;
+	private TimeManager timeManager;
 	private Map<String,Function<ACMetadata,byte[]>> attributeEncoders;
 
 	//----------------------------------------------------------
@@ -61,12 +64,14 @@ public class MomFederate
 	//----------------------------------------------------------
 	public MomFederate( Federate federate, 
 	                    ROCInstance federateObject, 
-	                    HLAVersion version, 
+	                    HLAVersion version,
+	                    TimeManager timeManager,
 	                    Logger momLogger )
 	{
 		this.federate = federate;
 		this.federateObject = federateObject;
 		this.version = version;
+		this.timeManager = timeManager;
 		this.momLogger = momLogger;
 		
 		// Map encoding functions against the canonical name of the attribute they provide data for
@@ -221,19 +226,20 @@ public class MomFederate
 	private byte[] getTimeConstrained( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		return MomEncodingHelpers.encode( type, federate.getTimeStatus().isConstrained() );
+		return MomEncodingHelpers.encode( type, timeManager.isConstrained(getFederateHandle()) );
 	}
 
 	private byte[] getTimeRegulating( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		return MomEncodingHelpers.encode( type, federate.getTimeStatus().isRegulating() );
+		return MomEncodingHelpers.encode( type, timeManager.isRegulating(getFederateHandle()) );
 	}
 
 	private byte[] getAsynchronousDelivery( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		return MomEncodingHelpers.encode( type, federate.getTimeStatus().isAsynchronous() );
+		TimeStatus status = timeManager.getTimeStatus( getFederateHandle() );
+		return MomEncodingHelpers.encode( type, status.isAsynchronous() );
 	}
 
 	private byte[] getFederateState( ACMetadata metadata )
@@ -249,19 +255,19 @@ public class MomFederate
 	private byte[] getFederateTime( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		return MomEncodingHelpers.encode( type, federate.getTimeStatus().getCurrentTime() );
+		return MomEncodingHelpers.encode( type, timeManager.getCurrentTime(getFederateHandle()) );
 	}
 
 	private byte[] getLookahead( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		return MomEncodingHelpers.encode( type, federate.getTimeStatus().getLookahead() );
+		return MomEncodingHelpers.encode( type, timeManager.getLookahead(getFederateHandle()) );
 	}
 
 	private byte[] getLBTS( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		return MomEncodingHelpers.encode( type, federate.getTimeStatus().getLbts() );
+		return MomEncodingHelpers.encode( type, timeManager.getLBTS(getFederateHandle()) );
 	}
 
 	private byte[] getMinNextEventTime( ACMetadata metadata )
@@ -366,13 +372,13 @@ public class MomFederate
 	private byte[] getTimeGrantedTime( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		return MomEncodingHelpers.encode( type, federate.getTimeStatus().getCurrentTime() );
+		return MomEncodingHelpers.encode( type, timeManager.getCurrentTime(getFederateHandle()) );
 	}
 
 	private byte[] getTimeAdvancingTime( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		return MomEncodingHelpers.encode( type, federate.getTimeStatus().getRequestedTime() );
+		return MomEncodingHelpers.encode( type, timeManager.getRequestedTime(getFederateHandle()) );
 	}
 	
 	private byte[] notYetSupported( String property )

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomFederate.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomFederate.java
@@ -287,10 +287,7 @@ public class MomFederate
 	private byte[] getReflectionsReceived( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		ObjectClassBasedCount[] updated = federate.getMetrics().getReflectionsReceived();
-		int grandTotal = 0;
-		for( ObjectClassBasedCount classCount : updated )
-			grandTotal += classCount.getCount();
+		int grandTotal = federate.getMetrics().getTotalReflectionsReceived();
 		
 		return MomEncodingHelpers.encode( type, grandTotal );
 	}
@@ -298,10 +295,7 @@ public class MomFederate
 	private byte[] getUpdatesSent( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		ObjectClassBasedCount[] updated = federate.getMetrics().getUpdatesSent();
-		int grandTotal = 0;
-		for( ObjectClassBasedCount classCount : updated )
-			grandTotal += classCount.getCount();
+		int grandTotal = federate.getMetrics().getTotalUpdatesSent();
 		
 		return MomEncodingHelpers.encode( type, grandTotal );
 	}
@@ -309,10 +303,7 @@ public class MomFederate
 	private byte[] getInteractionsReceived( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		InteractionCount[] received = federate.getMetrics().getInteractionsReceived();
-		int grandTotal = 0;
-		for( InteractionCount classCount : received )
-			grandTotal += classCount.getCount();
+		int grandTotal = federate.getMetrics().getTotalInteractionsReceived();
 		
 		return MomEncodingHelpers.encode( type, grandTotal );
 	}
@@ -320,10 +311,7 @@ public class MomFederate
 	private byte[] getInteractionsSent( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		InteractionCount[] received = federate.getMetrics().getInteractionsSent();
-		int grandTotal = 0;
-		for( InteractionCount classCount : received )
-			grandTotal += classCount.getCount();
+		int grandTotal = federate.getMetrics().getTotalInteractionsSent();
 		
 		return MomEncodingHelpers.encode( type, grandTotal );
 	}
@@ -338,10 +326,7 @@ public class MomFederate
 	private byte[] getObjectsUpdated( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		ObjectClassBasedCount[] updated = federate.getMetrics().getObjectInstancesUpdated();
-		int grandTotal = 0;
-		for( ObjectClassBasedCount classCount : updated )
-			grandTotal += classCount.getCount();
+		int grandTotal = federate.getMetrics().getTotalObjectInstancesUpdated();
 		
 		return MomEncodingHelpers.encode( type, grandTotal );
 	}
@@ -349,10 +334,7 @@ public class MomFederate
 	private byte[] getObjectsReflected( ACMetadata metadata )
 	{
 		IDatatype type = metadata.getDatatype();
-		ObjectClassBasedCount[] reflected = federate.getMetrics().getObjectInstancesReflected();
-		int grandTotal = 0;
-		for( ObjectClassBasedCount classCount : reflected )
-			grandTotal += classCount.getCount();
+		int grandTotal = federate.getMetrics().getTotalObjectInstancesReflected();
 		
 		return MomEncodingHelpers.encode( type, grandTotal );
 	}

--- a/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomManager.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/mom/data/MomManager.java
@@ -39,6 +39,7 @@ import org.portico2.rti.federation.Federate;
 import org.portico2.rti.federation.Federation;
 import org.portico2.rti.services.object.data.ROCInstance;
 import org.portico2.rti.services.object.data.Repository;
+import org.portico2.rti.services.time.data.TimeManager;
 
 /**
  * The MOM manager takes care of all the MOM related tasks for a {@link Federation}.
@@ -184,8 +185,11 @@ public class MomManager implements SaveRestoreTarget
 		repository.addObject( instance );
 
 		// wrap the HLA object instance in a MomFederation so we can track it
-		MomFederate momFederate =
-		    new MomFederate( federate, instance, federation.getHlaVersion(), this.logger );
+		MomFederate momFederate = new MomFederate( federate, 
+		                                           instance, 
+		                                           federation.getHlaVersion(),
+		                                           federation.getTimeManager(),
+		                                           this.logger );
 		this.momFederation.addFederate( momFederate );
 
 		if( this.isRestoring() )
@@ -342,12 +346,13 @@ public class MomManager implements SaveRestoreTarget
 			return;
 		
 		// NOTE: Assumes the federate has not been removed yet
+		TimeManager timeManager = federation.getTimeManager();
 		Federate lostFederate = federation.getFederate( federate );
 		
 		Map<String,Object> params = new HashMap<>();
 		params.put( "HLAfederate", federate );
 		params.put( "HLAfederateName", lostFederate.getFederateName() );
-		params.put( "HLAtimeStamp", lostFederate.getTimeStatus().getCurrentTime() );
+		params.put( "HLAtimeStamp", timeManager.getCurrentTime(federate) );
 		params.put( "HLAfaultDescription", faultDescription );
 		int federateLostHandle = Mom.getMomInteractionHandle( CANONICAL_VERSION,
 		                                                      "HLAmanager.HLAfederate.HLAreport.HLAreportFederateLost");

--- a/codebase/src/java/portico/org/portico2/rti/services/object/incoming/DeleteObjectHandler.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/object/incoming/DeleteObjectHandler.java
@@ -71,7 +71,7 @@ public class DeleteObjectHandler extends RTIMessageHandler
 		if( request.isTimestamped() )
 		{
 			Federate federate = federation.getFederate( sourceFederate );
-			TimeStatus timeStatus = federate.getTimeStatus();
+			TimeStatus timeStatus = timeManager.getTimeStatus( sourceFederate );
 			double time = request.getTimestamp();
 			// check that the time is greater than or equal to the current LBTS of this federate
 			if( time < timeStatus.getLbts() )


### PR DESCRIPTION
## RTI side message handlers don't check if the requesting Federate is an execution member #276

- `RtiInbox` now checks if the source federate that a "Federation" message is from is currently joined to that federation before handing the message off to the message sink for processing
- This prevents processing of messages from Federates that have been force resigned by external means (E.g. the console)

## Federate member timeStatus is never updated #277
- Removed stale Federate member timeStatus
- Updated all references to query the Federation's time manager instead (which is kept up to date)

## Also in this PR (because why not)

- Added pseudo file system and command handling to the skeleton CLI