### PR TITLE
Fix for Issue #286: Creating a Federation Execution with a `null` or empty FOM array throws NullPointerException/IndexOutOfBoundsException

### DIFF
--- a/codebase/src/java/portico/org/portico/impl/hla1516e/Rti1516eAmbassador.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516e/Rti1516eAmbassador.java
@@ -374,8 +374,9 @@ public abstract class Rti1516eAmbassador implements RTIambassador
 		// jam the MIM in at the front of the list of modules
 		ArrayList<URL> moduleList = new ArrayList<URL>();
 		moduleList.add( mimModule );
-		for( URL module : fomModules )
-			moduleList.add( module );
+		if( fomModules != null )
+			for( URL module : fomModules )
+				moduleList.add( module );
 
 		CreateFederation request = new CreateFederation( federationName, moduleList );
 		ResponseMessage response = processMessage( request );

--- a/codebase/src/java/portico/org/portico/lrc/model/ModelMerger.java
+++ b/codebase/src/java/portico/org/portico/lrc/model/ModelMerger.java
@@ -25,6 +25,7 @@ import java.util.Set;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.portico.impl.HLAVersion;
 import org.portico.lrc.compat.JInconsistentFDD;
 import org.portico.lrc.compat.JRTIinternalError;
 import org.portico.lrc.model.datatype.DatatypeHelpers;
@@ -72,13 +73,25 @@ public class ModelMerger
 	private ObjectModel mergeModels( List<ObjectModel> models ) throws JInconsistentFDD,
 	                                                                   JRTIinternalError
 	{
-		// if we only got one model, there's nothing to merge!
+		if( models.size() == 0 )
+		{
+			// we have no models, we need a 'root' level model
+			ObjectModel model = new ObjectModel();
+			boolean isHLA13 = model.getHlaVersion().equals( HLAVersion.HLA13 );
+			OCMetadata objectRoot = new OCMetadata( isHLA13 ? "ObjectRoot" : "HLAobjectRoot",
+			                                        model.generateHandle() );
+			objectRoot.setModel( model );
+			model.setObjectRoot( objectRoot );
+			return validate( model );
+		}
+		
 		if( models.size() == 1 )
 		{
+			// we have one or no models, there's nothing to merge!
 			ObjectModel model = models.get( 0 );
 			return validate( model );
 		}
-
+			
 		logger.trace( "Beginning merge of "+models.size()+" FOM models" );
 
 		// We have multiple models to merge

--- a/codebase/src/java/portico/org/portico/lrc/services/federation/handlers/outgoing/CreateFederationHandler.java
+++ b/codebase/src/java/portico/org/portico/lrc/services/federation/handlers/outgoing/CreateFederationHandler.java
@@ -19,7 +19,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import org.portico.impl.HLAVersion;
 import org.portico.lrc.LRCMessageHandler;
+import org.portico.lrc.compat.JCouldNotOpenFED;
 import org.portico.lrc.compat.JRTIinternalError;
 import org.portico.lrc.model.ModelMerger;
 import org.portico.lrc.model.ObjectModel;
@@ -64,6 +66,13 @@ public class CreateFederationHandler extends LRCMessageHandler
 		for( URL module : request.getFomModules() )
 			foms.add( FomParser.parse(module) );
 		
+		if( foms.isEmpty() )
+		{
+			HLAVersion version = this.lrc.getSpecHelper().getHlaVersion();
+			if( !version.equals( HLAVersion.IEEE1516e ) )
+				throw new JCouldNotOpenFED( "FED location provided was null or empty" );
+		}
+
 		// -- NOT DONE ANY MORE --
 		// Used to be important, but we will manually insert the MOM with handles we can control
 		// check to make sure we have the standard MIM as well - if not, load it

--- a/codebase/src/java/portico/org/portico/lrc/services/federation/msg/CreateFederation.java
+++ b/codebase/src/java/portico/org/portico/lrc/services/federation/msg/CreateFederation.java
@@ -60,22 +60,25 @@ public class CreateFederation extends PorticoMessage
 	{
 		this();
 		this.federationName = federationName;
-		this.fomModules.add( fedfileLocation );
+		if( fedfileLocation != null )
+			this.fomModules.add( fedfileLocation );
 	}
 	
 	public CreateFederation( String federationName, URL[] fomModules )
 	{
 		this();
 		this.federationName = federationName;
-		for( URL module : fomModules )
-			this.fomModules.add( module );
+		if( fomModules != null )
+			for( URL module : fomModules )
+				this.fomModules.add( module );
 	}
 	
 	public CreateFederation( String federationName, List<URL> fomModules )
 	{
 		this();
 		this.federationName = federationName;
-		this.fomModules.addAll( fomModules );
+		if( fomModules != null )
+			this.fomModules.addAll( fomModules );
 	}
 
 	//----------------------------------------------------------

--- a/codebase/src/java/test/hlaunit/ieee1516e/federation/CreateFederationTest.java
+++ b/codebase/src/java/test/hlaunit/ieee1516e/federation/CreateFederationTest.java
@@ -199,6 +199,36 @@ public class CreateFederationTest extends Abstract1516eTest
 		}
 	}
 	
+	@Test
+	public void testCreateFederationWithNullFomArray()
+	{
+		// attempt to create with null fom array //
+		try
+		{
+			URL[] foms = null;
+			defaultFederate.rtiamb.createFederationExecution( defaultFederate.simpleName, foms );
+		}
+		catch( Exception e )
+		{
+			Assert.fail( "Unexpected exception while testing create with null FOM array", e );
+		}
+	}
+	
+	@Test
+	public void testCreateFederationWithZeroLengthFomArray()
+	{
+		// attempt to create with empty fom array //
+		try
+		{
+			URL[] foms = new URL[0];
+			defaultFederate.rtiamb.createFederationExecution( defaultFederate.simpleName, foms );
+		}
+		catch( Exception e )
+		{
+			Assert.fail( "Unexpected exception while testing create with zero length FOM array", e );
+		}
+	}
+	
 	//////////////////////////////////////////////
 	// TEST: testCreateFederationWithNullName() //
 	//////////////////////////////////////////////


### PR DESCRIPTION
Attempts to create a federation execution with a null for the FOM modules parameter failed with a `NullPointerException`, and with an empty FOM modules array caused an `IndexOutOfBoundsException`.

A few places in the code caused this, depending on which version/method signature of the `createFederationExecution` method is invoked, but they all basically came down to an assumption that the `fomModules` parameter is never a null or empty array. These are...

`org.portico.lrc.services.federation.msg.CreateFederation`:
 - Added checks for a `null` URL (or URLs) in 3 constructor variants before processing to avoid `NullPointerException`

`org.portico.impl.hla1516e.Rti1516eAmbassador#createFederationExecution( String federationName, URL[] fomModules, URL mimModule )`:
 - added check for null `fomModules` array before processing to avoid `NullPointerException`

`org.portico.lrc.model.ModelMerger#mergeModels( List<ObjectModel> models )`:
 - added check for zero length `List` before processing to avoid `IndexOutOfBoundsException`

Two unit tests have also been added to cover the above situations and validate that behaviour is correct.

Tested with `release` build and all tests pass.