### PR TITLE
Fix combining multiple FOMs

### DIFF
--- a/codebase/src/java/portico/org/portico/lrc/model/ModelMerger.java
+++ b/codebase/src/java/portico/org/portico/lrc/model/ModelMerger.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.apache.log4j.Logger;
 import org.portico.lrc.compat.JInconsistentFDD;
@@ -194,7 +195,7 @@ public class ModelMerger
 		//////////////////////////////////
 		// check to see if there are any types in the extension that can be inserted into the base
 		// take copy of the set to avoid concurrent modificiation exceptions if we extend the model
-		Set<OCMetadata> extensionChildren = new HashSet<OCMetadata>( extension.getChildTypes() );
+		TreeSet<OCMetadata> extensionChildren = new TreeSet<OCMetadata>( extension.getChildTypes() );
 		for( OCMetadata extensionChild : extensionChildren )
 		{
 			// if the child does not exist in the base model, insert it, otherwise we need to
@@ -619,6 +620,7 @@ public class ModelMerger
 		}
 
 		// run a merge on the clones to ensure it passes happily
+		cloneList.get(0).unlock();
 		ModelMerger.merge( cloneList );
 	}
 }

--- a/codebase/src/java/portico/org/portico/lrc/model/OCMetadata.java
+++ b/codebase/src/java/portico/org/portico/lrc/model/OCMetadata.java
@@ -17,6 +17,7 @@ package org.portico.lrc.model;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.io.Serializable;
@@ -26,7 +27,7 @@ import org.portico.lrc.PorticoConstants;
 /**
  * This class contains metadata information about a FOM object class 
  */
-public class OCMetadata implements Serializable
+public class OCMetadata implements Serializable, Comparable<OCMetadata>
 {
 	//----------------------------------------------------------
 	//                    STATIC VARIABLES
@@ -58,7 +59,7 @@ public class OCMetadata implements Serializable
 		this.handle      = handle;
 		this.parent      = null;
 		this.attributes  = new HashMap<Integer,ACMetadata>();
-		this.children    = new HashSet<OCMetadata>();
+		this.children    = new TreeSet<OCMetadata>();
 	}
 	//----------------------------------------------------------
 	//                    INSTANCE METHODS
@@ -159,6 +160,16 @@ public class OCMetadata implements Serializable
 		
 		// remove our link to the model //
 		this.model = null;
+	}
+	
+	/**
+	 * Compares this object with the given one lexicographically based on their local names.
+	 * Needed so that children can use a TreeSet to be consistent across different federates
+	 * @see String#compareTo(String)
+	 */
+	public int compareTo(OCMetadata object)
+	{
+		return object.getLocalName().compareTo( this.getLocalName() );
 	}
 
 	////////////////////////////////////////////////////////////


### PR DESCRIPTION
Replaces several uses of HashSets with TreeSets in/around OCMetaData

Previously Hashset were used for adding in objects from FOMs,
however the order that objects returned by the iterator is not
fixed, so different federates could add objects in different orders,
causing handle mismatches. TreeSets however will always return the same
set in the same order, so no handle mismatches.