### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
 language: java
 jdk:
-  - openjdk8
+  - openjdk15
+
+dist: bionic
 
 install:
   - cd codebase


### PR DESCRIPTION
Updates travis to use bionic linux,
which supports required versions of gcc and java