### PR TITLE
Stop producing federate from receiving DiscoverObjectCalls on its own object

### DIFF
--- a/codebase/src/java/portico/org/portico2/rti/services/object/incoming/RegisterObjectHandler.java
+++ b/codebase/src/java/portico/org/portico2/rti/services/object/incoming/RegisterObjectHandler.java
@@ -124,8 +124,9 @@ public class RegisterObjectHandler extends RTIMessageHandler
 
 		DiscoverObject discover = fill( new DiscoverObject(newInstance), federateHandle );
 		subscriptions.remove( federateHandle ); // don't need to notify the one who created it
-		
-		super.queueManycast( discover, subscriptions.keySet() );
+
+		if ( !subscriptions.isEmpty() )
+			super.queueManycast( discover, subscriptions.keySet() );
 	}
 
 	/**


### PR DESCRIPTION
The RegisterObjectHandler sends a ManyCast message to all subscribed federates when a new object is created. The producing federate is removed from the list of subscribed federates, to prevent it from receiving a Discover message on its own objects. However, if no other federates subscribe to the object class, the list of subscribers is empty. The queueManycast method takes an empty list of recipients to mean that the message should be broadcast to everybody, meaning the producing federate will receive a DiscoverObject call on its own object. Fixed by adding a check to avoid sending the DiscoverObject message when the list of recipients is empty.