### PR TITLE
Ensure that Time Constrained federates receive messages in timestamped order

### DIFF
--- a/codebase/src/java/portico/org/portico2/common/messaging/MessageType.java
+++ b/codebase/src/java/portico/org/portico2/common/messaging/MessageType.java
@@ -120,14 +120,14 @@ public enum MessageType
 	
 	// Management Object Model (150-159)
 	SetServiceReporting     ( (short)150 ),
-	SetExceptionReporting   ( (short)151 );
+	SetExceptionReporting   ( (short)151 ),
 	
 	// Reserved for future use (160-253)
 	
 	// RESERVED (UPDATE/SEND - 254, 255 - Above)
 	
 	// Messages that are for processing within a specific federation
-	// ...
+	FederationLBTS((short) 255);
 	// ...
 	
 

--- a/codebase/src/java/portico/org/portico2/common/services/time/msg/FederationLBTS.java
+++ b/codebase/src/java/portico/org/portico2/common/services/time/msg/FederationLBTS.java
@@ -1,0 +1,64 @@
+package org.portico2.common.services.time.msg;
+
+import org.portico.utils.messaging.PorticoMessage;
+import org.portico2.common.messaging.MessageType;
+
+import java.io.IOException;
+import java.io.ObjectInput;
+import java.io.ObjectOutput;
+
+public class FederationLBTS extends PorticoMessage {
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+	private static final long serialVersionUID = 98121116105109L;
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+	private double federationLBTS;
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+	public FederationLBTS(double federationLBTS) {
+		this.federationLBTS = federationLBTS;
+	}
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+
+	@Override
+	public MessageType getType() {
+		return MessageType.FederationLBTS;
+	}
+
+	public double getFederationLBTS() {
+		return federationLBTS;
+	}
+
+	public void setFederationLBTS(double federationLBTS) {
+		this.federationLBTS = federationLBTS;
+	}
+
+	/////////////////////////////////////////////////////////////
+	/////////////////// Serialization Methods ///////////////////
+	/////////////////////////////////////////////////////////////
+	public void readExternal( ObjectInput input ) throws IOException, ClassNotFoundException
+	{
+		super.readExternal( input );
+		this.federationLBTS = input.readDouble();
+	}
+
+	public void writeExternal( ObjectOutput output ) throws IOException
+	{
+		super.writeExternal( output );
+
+		output.writeDouble(this.federationLBTS);
+	}
+
+	//----------------------------------------------------------
+	//                     STATIC METHODS
+	//----------------------------------------------------------
+}

--- a/codebase/src/java/portico/org/portico2/lrc/LRCHandlerRegistry.java
+++ b/codebase/src/java/portico/org/portico2/lrc/LRCHandlerRegistry.java
@@ -71,6 +71,7 @@ import org.portico2.lrc.services.pubsub.outgoing.UnsubscribeInteractionClassHand
 import org.portico2.lrc.services.pubsub.outgoing.UnsubscribeObjectClassHandler;
 import org.portico2.lrc.services.sync.outgoing.AchieveSyncPointHandler;
 import org.portico2.lrc.services.sync.outgoing.RegisterSyncPointHandler;
+import org.portico2.lrc.services.time.incoming.FederationLBTSHandler;
 import org.portico2.lrc.services.time.incoming.TimeAdvanceGrantHandler;
 import org.portico2.lrc.services.time.outgoing.DisableAsyncDeliveryHandler;
 import org.portico2.lrc.services.time.outgoing.DisableTimeConstrainedHandler;
@@ -204,6 +205,7 @@ public class LRCHandlerRegistry
 		in.register( MessageType.EnableTimeRegulation,    new TimeRegulationEnabledCallbackHandler() );
 		in.register( MessageType.TimeAdvanceGrant,        new TimeAdvanceGrantHandler() );
 		in.register( MessageType.TimeAdvanceGrant,        new TimeAdvanceGrantCallbackHandler() );
+		in.register( MessageType.FederationLBTS,          new FederationLBTSHandler());
 
 		// Ownership Management
 		in.register( MessageType.AttributeAcquire,        new AttributeReleaseRequestIncomingHandler() );

--- a/codebase/src/java/portico/org/portico2/lrc/LRCMessageQueue.java
+++ b/codebase/src/java/portico/org/portico2/lrc/LRCMessageQueue.java
@@ -253,7 +253,7 @@ public class LRCMessageQueue //implements SaveRestoreTarget
 					// it is! release it - we also need to remove it, so we'll poll
 					return this.tsoQueue.poll();
 				}
-				else if( message.getTimestamp() <= timeStatus.getRequestedTime() )
+				else if( message.getTimestamp() <= state.getFederationLbts() )
 				{
 					// it is! release it - we also need to remove it, so we'll poll
 					return this.tsoQueue.poll();

--- a/codebase/src/java/portico/org/portico2/lrc/LRCState.java
+++ b/codebase/src/java/portico/org/portico2/lrc/LRCState.java
@@ -57,6 +57,7 @@ public class LRCState
 	
 	// Time related settings //
 	private TimeStatus timeStatus;
+	private double federationLbts;
 	private boolean ticking;
 	private boolean callbacksEnabled;
 	private boolean immediateCallbacks;
@@ -421,6 +422,14 @@ public class LRCState
 		}
 		
 		this.ticking = ticking;
+	}
+
+	public double getFederationLbts() {
+		return federationLbts;
+	}
+
+	public void setFederationLbts(double federationLbts) {
+		this.federationLbts = federationLbts;
 	}
 
 	public double getCurrentTime()

--- a/codebase/src/java/portico/org/portico2/lrc/services/time/incoming/FederationLBTSHandler.java
+++ b/codebase/src/java/portico/org/portico2/lrc/services/time/incoming/FederationLBTSHandler.java
@@ -1,0 +1,45 @@
+package org.portico2.lrc.services.time.incoming;
+
+import org.portico.lrc.compat.JConfigurationException;
+import org.portico.lrc.compat.JException;
+import org.portico2.common.messaging.MessageContext;
+import org.portico2.common.services.time.msg.FederationLBTS;
+import org.portico2.lrc.LRCMessageHandler;
+
+import java.util.Map;
+
+public class FederationLBTSHandler extends LRCMessageHandler {
+	//----------------------------------------------------------
+	//                    STATIC VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                   INSTANCE VARIABLES
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                      CONSTRUCTORS
+	//----------------------------------------------------------
+
+	//----------------------------------------------------------
+	//                    INSTANCE METHODS
+	//----------------------------------------------------------
+	@Override
+	public void configure( Map<String,Object> properties ) throws JConfigurationException
+	{
+		super.configure( properties );
+	}
+
+	@Override
+	public void process(MessageContext context) throws JException {
+		FederationLBTS message = context.getRequest(FederationLBTS.class, this);
+
+		double federationLBTS = message.getFederationLBTS();
+
+		lrcState.setFederationLbts(federationLBTS);
+
+		if (logger.isDebugEnabled()) {
+			logger.debug("FEDERATION LBTS advanced to time ["+federationLBTS+"]");
+		}
+	}
+}


### PR DESCRIPTION
Page 21 of the HLA standard defines timestamp order (TSO) as the guarantee that if two messages M1 and M2 have timestamps T1 and T2, then message M1 will always be delivered to a time-constrained federate before message M2 if T1<T2.

At the moment, timestamped messages can be polled from the LRC Message Queue as long as their timestamp is lower than the time the federate has currently requested to advance to. However, there is no guarantee that the federate might not receive a message with a lower timestamp than this later on, since the federate might request to advance to an arbitrary timestamp, and other federates might have a smaller lower bound on timestamp than this.

The CRC currently maintains a federation wide lower bound on timestamp. If the LRCs were aware of this, they could make sure to only return messages with a lower timestamp than this, meaning no new messages with a similar timestamp could be added later. This would guarantee that all messages are delivered in timestamp order.

This merge adds a message class to broadcast the federation LBTS to all LRCs whenever it changes. The federation LBTS is recalculated each time a federate requests to advance, so some code was added to broadcast this message whenever the LBTS changes. The LRCs receive the broadcast message and store the current federation LBTS in their LRCState, and can then check against this whenever deciding to return a message from the TSO queue.

Possible bug: There are other places in the code where the federation wide LBTS is recalculated. These do not currently trigger an LBTS broadcast message.