### PR TITLE
Only deliver ProvideAttributeValueUpdate callbacks to the owning federate

### DIFF
--- a/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/ProvideUpdateCallbackHandler.java
+++ b/codebase/src/java/portico/org/portico/impl/hla1516e/handlers2/ProvideUpdateCallbackHandler.java
@@ -14,9 +14,11 @@
  */
 package org.portico.impl.hla1516e.handlers2;
 
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+import hla.rti1516e.AttributeHandle;
 import org.portico.impl.hla1516e.types.HLA1516eAttributeHandleSet;
 import org.portico.impl.hla1516e.types.HLA1516eHandle;
 import org.portico.lrc.compat.JConfigurationException;
@@ -26,6 +28,7 @@ import org.portico2.common.services.object.msg.RequestObjectUpdate;
 import hla.rti1516e.AttributeHandleSet;
 import hla.rti1516e.ObjectInstanceHandle;
 import hla.rti1516e.exceptions.FederateInternalError;
+import org.portico2.lrc.services.object.data.LOCInstance;
 
 public class ProvideUpdateCallbackHandler extends LRC1516eCallbackHandler
 {
@@ -64,18 +67,37 @@ public class ProvideUpdateCallbackHandler extends LRC1516eCallbackHandler
 			logger.trace( "CALLBACK provideAttributeValueUpdate(object="+objectHandle+
 			              ",attributes="+attributes+")" );
 		}
-		
-		// do the callback
-		fedamb().provideAttributeValueUpdate( objectHandle,
-		                                      ahs,
-		                                      tag );
-		helper.reportServiceInvocation( "provideAttributeValueUpdate", 
-		                                true, 
-		                                null, 
-		                                objectHandle,
-		                                ahs,
-		                                tag );
 
+		// Remove attributes from the callback that are not owned by this federate
+		LOCInstance object = helper.getState().getRepository().getObject(request.getObjectId());
+
+		Iterator<AttributeHandle> ahsIterator = ahs.iterator();
+		while ( ahsIterator.hasNext() ) {
+			AttributeHandle attributeHandle = ahsIterator.next();
+			int attributeHandleInt = HLA1516eHandle.fromHandle(attributeHandle);
+
+			if ( !object.getAttribute(attributeHandleInt).isOwnedBy(helper.getState().getFederateHandle()) ) {
+				ahsIterator.remove();
+			}
+		}
+
+		// If there are any owned attributes left, do the callback
+		if ( !ahs.isEmpty() ) {
+			// do the callback
+			fedamb().provideAttributeValueUpdate(objectHandle,
+					ahs,
+					tag);
+			helper.reportServiceInvocation("provideAttributeValueUpdate",
+					true,
+					null,
+					objectHandle,
+					ahs,
+					tag);
+
+		} else {
+			if ( logger.isTraceEnabled() )
+				logger.trace("CALLBACK provideAttributeValueUpdate(object="+objectHandle+"): no attributes owned by federate");
+		}
 		context.success();
 		
 		if( logger.isTraceEnabled() )


### PR DESCRIPTION
Currently, ProvideAttributeValueUpdate callbacks seem to be delivered to all connected federates, even though they don't own any attributes of the object in question. Added a check that only delivers the callback for attributes that are actually owned by the federate, and doesn't deliver the callback if no attributes are owned.