### PR TITLE
Update the 1516e spec classes to be Java 21 compatible

### DIFF
--- a/codebase/src/java/portico/hla/rti1516e/LogicalTimeFactoryFactory.java
+++ b/codebase/src/java/portico/hla/rti1516e/LogicalTimeFactoryFactory.java
@@ -2,27 +2,22 @@
  * The IEEE hereby grants a general, royalty-free license to copy, distribute,
  * display and make derivative works from this material, for all purposes,
  * provided that any use of the material contains the following
- * attribution: "Reprinted with permission from IEEE 1516.1(TM)-2010".
+ * attribution: "Reprinted with permission from IEEE 1516.1(TM)-201X".
  * Should you require additional information, contact the Manager, Standards
  * Intellectual Property, IEEE Standards Association (stds-ipr@ieee.org).
  */
 
 package hla.rti1516e;
 
-import javax.imageio.spi.ServiceRegistry;
-
-import org.portico.impl.hla1516e.types.time.DoubleTimeFactory;
-import org.portico.impl.hla1516e.types.time.LongTimeFactory;
-
 import java.util.HashSet;
-//import java.util.Iterator;
+import java.util.ServiceLoader;
 import java.util.Set;
 
 /**
  * Helper class for locating LogicalTimeFactory. Uses Service concept described
- * by ServiceRegistry.
+ * by ServiceLoader.
  *
- * @see ServiceRegistry
+ * @see ServiceLoader
  */
 public class LogicalTimeFactoryFactory {
    /**
@@ -41,59 +36,33 @@ public class LogicalTimeFactoryFactory {
       if (name.equals("")) {
          name = "HLAfloat64Time";
       }
-      /** Java 9 syas NO ServiceRegistry use for generic types
-      Iterator<LogicalTimeFactory> i = ServiceRegistry.lookupProviders(LogicalTimeFactory.class);
-      while (i.hasNext()) {
-         LogicalTimeFactory logicalTimeFactory = i.next();
+      ServiceLoader<LogicalTimeFactory> loader = ServiceLoader.load(LogicalTimeFactory.class);
+      for (LogicalTimeFactory logicalTimeFactory : loader) {
          if (logicalTimeFactory.getName().equals(name)) {
             return logicalTimeFactory;
          }
       }
-      return null;*/
-
-      if( name.equalsIgnoreCase("HLAfloat64Time") )
-    	  return new DoubleTimeFactory();
-      else if( name.equalsIgnoreCase("HLAinteger64Time") )
-    	  return new LongTimeFactory();
-      else
-    	  return null;
+      return null;
    }
 
    public static <T extends LogicalTimeFactory> T getLogicalTimeFactory(Class<T> logicalTimeFactoryClass)
    {
-      /** Java 9 syas NO ServiceRegistry use for generic types
-      Iterator<LogicalTimeFactory> i = ServiceRegistry.lookupProviders(LogicalTimeFactory.class);
-      while (i.hasNext()) {
-         LogicalTimeFactory logicalTimeFactory = i.next();
+      ServiceLoader<LogicalTimeFactory> loader = ServiceLoader.load(LogicalTimeFactory.class);
+      for (LogicalTimeFactory logicalTimeFactory : loader) {
          if (logicalTimeFactoryClass.isInstance(logicalTimeFactory)) {
             return logicalTimeFactoryClass.cast(logicalTimeFactory);
          }
       }
-      return null;*/
-
-      if( logicalTimeFactoryClass.isInstance(new DoubleTimeFactory()) )
-          return logicalTimeFactoryClass.cast( new DoubleTimeFactory() );
-      else if( logicalTimeFactoryClass.isInstance(new LongTimeFactory()) )
-          return logicalTimeFactoryClass.cast( new LongTimeFactory() );
-      else
-    	  return null;
-      
+      return null;
    }
 
    public static Set<LogicalTimeFactory> getAvailableLogicalTimeFactories()
    {
       Set<LogicalTimeFactory> factories = new HashSet<LogicalTimeFactory>();
-      factories.add( new DoubleTimeFactory() );
-      factories.add( new LongTimeFactory() );
-      return factories;
-
-      /** Java 9 syas NO ServiceRegistry use for generic types
-      Iterator<LogicalTimeFactory> i = ServiceRegistry.lookupProviders(LogicalTimeFactory.class);
-      Set<LogicalTimeFactory> factories = new HashSet<LogicalTimeFactory>();
-      while (i.hasNext()) {
-         LogicalTimeFactory logicalTimeFactory = i.next();
+      ServiceLoader<LogicalTimeFactory> loader = ServiceLoader.load(LogicalTimeFactory.class);
+      for (LogicalTimeFactory logicalTimeFactory : loader) {
          factories.add(logicalTimeFactory);
       }
-      return factories;*/
+      return factories;
    }
 }

--- a/codebase/src/java/portico/hla/rti1516e/RtiFactoryFactory.java
+++ b/codebase/src/java/portico/hla/rti1516e/RtiFactoryFactory.java
@@ -2,7 +2,7 @@
  * The IEEE hereby grants a general, royalty-free license to copy, distribute,
  * display and make derivative works from this material, for all purposes,
  * provided that any use of the material contains the following
- * attribution: "Reprinted with permission from IEEE 1516.1(TM)-2010".
+ * attribution: "Reprinted with permission from IEEE 1516.1(TM)-201X".
  * Should you require additional information, contact the Manager, Standards
  * Intellectual Property, IEEE Standards Association (stds-ipr@ieee.org).
  */
@@ -11,63 +11,49 @@ package hla.rti1516e;
 
 import hla.rti1516e.exceptions.RTIinternalError;
 
-import javax.imageio.spi.ServiceRegistry;
-
-import org.portico.impl.hla1516e.Rti1516eFactory;
-
 import java.util.HashSet;
-//import java.util.Iterator;
+import java.util.Iterator;
+import java.util.ServiceLoader;
 import java.util.Set;
 
 /**
  * Helper class for locating RtiFactory. Uses Service concept described
- * by ServiceRegistry.
+ * by ServiceLoader.
  *
- * @see ServiceRegistry
+ * @see ServiceLoader
  */
 public class RtiFactoryFactory {
    public static RtiFactory getRtiFactory(String name)
       throws
       RTIinternalError
    {
-	  /** Java 9 syas NO ServiceRegistry use for generic types
-      Iterator<RtiFactory> i = ServiceRegistry.lookupProviders(RtiFactory.class);
-      while (i.hasNext()) {
-         RtiFactory rtiFactory = i.next();
+      ServiceLoader<RtiFactory> loader = ServiceLoader.load(RtiFactory.class);
+      for (RtiFactory rtiFactory : loader) {
          if (rtiFactory.rtiName().equals(name)) {
             return rtiFactory;
          }
       }
       throw new RTIinternalError("Cannot find factory matching " + name);
-      */
-	  return new Rti1516eFactory();
    }
 
    public static RtiFactory getRtiFactory()
       throws
       RTIinternalError
    {
-	  /** Java 9 syas NO ServiceRegistry use for generic types
-      Iterator<RtiFactory> i = ServiceRegistry.lookupProviders(RtiFactory.class);
-      if (i.hasNext()) {
-         return i.next();
+      ServiceLoader<RtiFactory> loader = ServiceLoader.load(RtiFactory.class);
+      for (RtiFactory rtiFactory : loader) {
+         return rtiFactory;
       }
-      throw new RTIinternalError("Cannot find factory");*/
-	  return new Rti1516eFactory();
+      throw new RTIinternalError("Cannot find factory");
    }
 
    public static Set<RtiFactory> getAvailableRtiFactories()
    {
       Set<RtiFactory> factories = new HashSet<RtiFactory>();
-      factories.add( new Rti1516eFactory() );
-      return factories;
-      /** Java 9 syas NO ServiceRegistry use for generic types
-      Iterator<RtiFactory> i = ServiceRegistry.lookupProviders(RtiFactory.class);
-      Set<RtiFactory> factories = new HashSet<RtiFactory>();
-      while (i.hasNext()) {
-         RtiFactory rtiFactory = i.next();
+      ServiceLoader<RtiFactory> loader = ServiceLoader.load(RtiFactory.class);
+      for (RtiFactory rtiFactory : loader) {
          factories.add(rtiFactory);
       }
-      return factories;*/
+      return factories;
    }
 }


### PR DESCRIPTION
The 1516e spec made some questionable decisions around using SPI classes for things other than what they were designed for. This caused things to break post Java 9. This borrows the spec from HLA4 for the two impacted classes, which resolves this issue.