### PR TITLE
Reduce message bundling default timeout from 30ms to 5ms

### DIFF
--- a/codebase/resources/dist/common/RTI.rid
+++ b/codebase/resources/dist/common/RTI.rid
@@ -201,7 +201,7 @@
 #
 # portico.jgroups.bundling = true
 # portico.jgroups.bundling.maxSize = 64K
-# portico.jgroups.bundling.maxTime = 30
+# portico.jgroups.bundling.maxTime = 5
 
 
 # (4.6) JGroups Flow Control

--- a/codebase/resources/jars/portico.jar/etc/jgroups-udp.xml
+++ b/codebase/resources/jars/portico.jar/etc/jgroups-udp.xml
@@ -13,7 +13,7 @@
          
          enable_bundling="${portico.jgroups.bundling:true}"
          max_bundle_size="${portico.jgroups.bundling.maxSize:64K}"
-         max_bundle_timeout="${portico.jgroups.bundling.maxTime:30}"
+         max_bundle_timeout="${portico.jgroups.bundling.maxTime:5}"
 
          timer_type="new"
          timer.min_threads="4"

--- a/codebase/src/java/examples/hla13/RTI.rid
+++ b/codebase/src/java/examples/hla13/RTI.rid
@@ -201,7 +201,7 @@
 #
 # portico.jgroups.bundling = true
 # portico.jgroups.bundling.maxSize = 64K
-# portico.jgroups.bundling.maxTime = 30
+# portico.jgroups.bundling.maxTime = 5
 
 
 # (4.6) JGroups Flow Control

--- a/codebase/src/java/examples/ieee1516e/RTI.rid
+++ b/codebase/src/java/examples/ieee1516e/RTI.rid
@@ -201,7 +201,7 @@
 #
 # portico.jgroups.bundling = true
 # portico.jgroups.bundling.maxSize = 64K
-# portico.jgroups.bundling.maxTime = 30
+# portico.jgroups.bundling.maxTime = 5
 
 
 # (4.6) JGroups Flow Control


### PR DESCRIPTION
Message bundling is enabled by default, and the default timeout is 30ms. This value is too high for all but the most chatty federations, and has the impact of increasing default latency. Reducing it down to 5ms feels like it balances responsiveness with a desire to not generate a packet flood on networks.

Fix: #349