### PR TITLE
Update example scripts so javac calls enable annotation processing

### DIFF
--- a/codebase/src/java/examples/event-logger/linux.sh
+++ b/codebase/src/java/examples/event-logger/linux.sh
@@ -54,7 +54,7 @@ if [ $1 = "compile" ]
 then
 	echo "compiling example federate"
 	cd src
-	javac -cp ./:$RTI_HOME/lib/portico.jar *.java
+	javac -proc:full -cp ./:$RTI_HOME/lib/portico.jar *.java
 	jar -cf ../event-logger.jar *.class
 	cd ../
 	exit;

--- a/codebase/src/java/examples/event-logger/win32.bat
+++ b/codebase/src/java/examples/event-logger/win32.bat
@@ -59,7 +59,7 @@ rem ############################################
 :compile
 echo "compiling example federate"
 cd src
-%JAVAC% -cp ".;%RTI_HOME%\lib\portico.jar" *.java
+%JAVAC%  -proc:full -cp ".;%RTI_HOME%\lib\portico.jar" *.java
 %JAR% -cf ..\event-logger.jar *.class
 cd ..
 goto finish

--- a/codebase/src/java/examples/hla13/linux.sh
+++ b/codebase/src/java/examples/hla13/linux.sh
@@ -54,7 +54,7 @@ if [ $1 = "compile" ]
 then
 	echo "compiling example federate"
 	cd src
-	javac -cp ./:$RTI_HOME/lib/portico.jar hla13/*.java
+	javac -proc:full -cp ./:$RTI_HOME/lib/portico.jar hla13/*.java
 	jar -cf ../java-hla13.jar hla13/*.class
 	cd ../
 	exit;	

--- a/codebase/src/java/examples/hla13/windows.bat
+++ b/codebase/src/java/examples/hla13/windows.bat
@@ -59,7 +59,7 @@ rem ############################################
 :compile
 echo "compiling example federate"
 cd src
-%JAVAC% -cp ".;%RTI_HOME%\lib\portico.jar" hla13\*.java
+%JAVAC% -proc:full -cp ".;%RTI_HOME%\lib\portico.jar" hla13\*.java
 %JAR% -cf ..\java-hla13.jar hla13\*.class
 cd ..
 goto finish

--- a/codebase/src/java/examples/hla13java1/linux.sh
+++ b/codebase/src/java/examples/hla13java1/linux.sh
@@ -54,7 +54,7 @@ if [ $1 = "compile" ]
 then
 	echo "compiling example federate"
 	cd src
-	javac -cp ./:$RTI_HOME/lib/portico.jar hla13java1/*.java
+	javac -proc:full -cp ./:$RTI_HOME/lib/portico.jar hla13java1/*.java
 	jar -cf ../java-hla13java1.jar hla13java1/*.class
 	cd ../
 	exit;	

--- a/codebase/src/java/examples/hla13java1/windows.bat
+++ b/codebase/src/java/examples/hla13java1/windows.bat
@@ -59,7 +59,7 @@ rem ############################################
 :compile
 echo "compiling example federate"
 cd src
-%JAVAC% -cp ".;%RTI_HOME%\lib\portico.jar" hla13java1\*.java
+%JAVAC% -proc:full -cp ".;%RTI_HOME%\lib\portico.jar" hla13java1\*.java
 %JAR% -cf ..\java-hla13java1.jar hla13java1\*.class
 cd ..
 goto finish

--- a/codebase/src/java/examples/ieee1516e/linux.sh
+++ b/codebase/src/java/examples/ieee1516e/linux.sh
@@ -54,7 +54,7 @@ if [ $1 = "compile" ]
 then
 	echo "compiling example federate"
 	cd src
-	javac -cp ./:$RTI_HOME/lib/portico.jar ieee1516e/*.java
+	javac -proc:full -cp ./:$RTI_HOME/lib/portico.jar ieee1516e/*.java
 	jar -cf ../java-ieee1516e.jar ieee1516e/*.class
 	cd ../
 	exit;	

--- a/codebase/src/java/examples/ieee1516e/windows.bat
+++ b/codebase/src/java/examples/ieee1516e/windows.bat
@@ -59,7 +59,7 @@ rem ############################################
 :compile
 echo "compiling example federate"
 cd src
-%JAVAC% -cp ".;%RTI_HOME%\lib\portico.jar" ieee1516e\*.java
+%JAVAC% -proc:full -cp ".;%RTI_HOME%\lib\portico.jar" ieee1516e\*.java
 %JAR% -cf ..\java-ieee1516e.jar ieee1516e\*.class
 cd ..
 goto finish


### PR DESCRIPTION
This isn't strictly necessary, but without it <javac> will issue warnings. We have lots of libraries on the classpath that use annotation processing, so this warning will forever pop up. The least we can do is show how to get rid of the warning. Without annotation processing the RTI as it exists today may well break (won't be able to discover handlers), so it can't hurt to just enable it explicitly.