### PR TITLE
Ensure line-endings in Changelog are consistent with build platform

### DIFF
--- a/codebase/profiles/java.xml
+++ b/codebase/profiles/java.xml
@@ -261,6 +261,7 @@
 		<chmod dir="${sandbox.examples.dir}" perm="777" includes="**/*.sh"/>
 		
 		<!-- Run platform specific fixes such as fixing crlf for Windows bound files! -->
+		<fixcrlf srcdir="${sandbox.dir}" includes="Changelog.md"/>
 	</target>
 
 	<!-- ==================================== -->


### PR DESCRIPTION
Our Git repo should have all line-endings in Unix format. Depending on your Git configuration, when checking out on different platforms you may or may not have that changed to values appropriate for the local platform. This commit adds a conversion for the Changelog as part of building the sandbox to make sure that line endings are always in the correct format for the platform that the build is running on.

Fix: #78