### PR TITLE
Fix bug preventing JGroups federates from updating FOMs after peer join

### DIFF
--- a/codebase/src/java/portico/org/portico/bindings/jgroups/Federation.java
+++ b/codebase/src/java/portico/org/portico/bindings/jgroups/Federation.java
@@ -496,7 +496,8 @@ public class Federation
 		}
 	}
 
-	public void receiveSetManifest( UUID sender, byte[] payload )
+	@SuppressWarnings("deprecation")
+	public synchronized void receiveSetManifest( UUID sender, byte[] payload )
 	{
 		// if we already have a manifest, AND we are the coordinator, ignore as we sent this out
 		// otherwise, take the updated manifest
@@ -534,6 +535,11 @@ public class Federation
 			// Update our local manifest
 			manifest.setLocalUUID( this.uuid );
 			this.manifest = manifest;
+			
+			// Push the updated FOM into our LRC State
+			if( joinedLRC != null )
+				joinedLRC.getState().remoteJGroupsManifestReceivedHack( this.manifest.getFom() );
+			
 			logger.debug( "Installed new manifest (follows)" );
 			logger.debug( manifest );
 		}

--- a/codebase/src/java/portico/org/portico/lrc/LRCState.java
+++ b/codebase/src/java/portico/org/portico/lrc/LRCState.java
@@ -262,6 +262,21 @@ public class LRCState extends NullNotificationListener implements SaveRestoreTar
 		federation.addFederate( federate );
 		momManager.federateJoinedFederation( federate );
 	}
+
+	/**
+	 * This is an UGLY, UGLY hack that I'm marking as deprecated right from the outset!
+	 * This should never be called by any code except JGroups. It allows us to push into
+	 * the state an updated FOM that we have received due to a remote federate joining
+	 * the federation (which may have added some modules). This is specific to JGroups.
+	 * 
+	 * @param updated The updated object model that came as part of the manifest update
+	 */
+	@Deprecated
+	public void remoteJGroupsManifestReceivedHack( ObjectModel updated )
+	{
+		if( updated != null )
+			this.fom = updated;
+	}
 	
 	/**
 	 * This notification is invoked when a remote federate joins the federation the local federate

--- a/codebase/src/java/test/hlaunit/ieee1516e/federation/FederationConsistencyTest.java
+++ b/codebase/src/java/test/hlaunit/ieee1516e/federation/FederationConsistencyTest.java
@@ -104,10 +104,10 @@ public class FederationConsistencyTest extends Abstract1516eTest
 		defaultFederate.quickCreateWithModules( moduleMain );
 
 		// 2. Join federation with additional modules in default federate
-		defaultFederate.quickJoinWithModules( moduleMain, moduleFood, moduleDrink, moduleSoup );
+		defaultFederate.quickJoinWithModules( moduleMain, moduleFood );
 
 		// 3. Join federation in second federate with same modules as default, but in different order
-		secondFederate.quickJoinWithModules( moduleSoup, moduleDrink );
+		secondFederate.quickJoinWithModules( moduleSoup );
 		
 		// 4. Repeat for a third federate - different module order again
 		thirdFederate.quickJoinWithModules( moduleDrink );


### PR DESCRIPTION
The FOM is set in the LRCState when a federate joins a federation. If another federate subsequently joins the federation and extends the FOM, and it happens to add modules, peer JGroups federate would never have their local FOM updated, so they never knew the new types existed.

This update fixes that and pushes in new object models received as a result of remote peer joins.

Working: #188