### PR TITLE
Adds Win32 (vc14_1) build support for portico-2.1.x

### DIFF
--- a/codebase/build.xml
+++ b/codebase/build.xml
@@ -59,6 +59,10 @@
 	        description="Generate a standard release package, but skip the tests"
 	        depends="clean,build.release,sandbox,installer,java.sandbox.jre"/>
 	
+	<target name="release.32"
+	        description="Clean, run all test sand generate a standard release package"
+	        depends="clean,build.release.32,java.sandbox,cpp.hla13-32.sandbox,cpp.ieee1516e-32.sandbox,installer-32.nsis.win32"/>
+
 	<!-- =========================================================== -->
 	<!--                      Extension Points                       -->
 	<!-- =========================================================== -->
@@ -101,6 +105,10 @@
 	<import file="profiles/windows/ieee1516e.xml"   as="cpp.ieee1516e" if="platform.windows"/>
 	<import file="profiles/windows/installer.xml"   as="installer"     if="platform.windows"/>
 
+	<import file="profiles/windows/hla13-32.xml"     as="cpp.hla13-32"     if="platform.windows"/>
+	<import file="profiles/windows/ieee1516e-32.xml" as="cpp.ieee1516e-32" if="platform.windows"/>
+	<import file="profiles/windows/installer-32.xml" as="installer-32"     if="platform.windows"/>
+
 	<!-- Deployment Tasks -->
 	<!--<include file="profiles/deploy.xml"              as="deploy"/>-->
 
@@ -122,6 +130,11 @@
 	<target name="build.release">
 		<echo>Build flagged as a release build. Setting build.release property to true</echo>
 		<property name="build.release" value="true"/>
+	</target>
+
+	<!-- Flag to control whether the 32-bit targets will run or not -->
+	<target name="build.release.32" depends="build.release">
+		<property name="build.release.32" value="true"/>
 	</target>
 
 </project>

--- a/codebase/profiles/java.xml
+++ b/codebase/profiles/java.xml
@@ -347,6 +347,11 @@
 		<copy-jre outdir="${sandbox.dir}"/>
 	</target>
 	
+	<target name="sandbox.jre32" description="Copy the JRE into the sandbox">
+		<mkdir dir="${sandbox.dir}"/>
+		<copy-jre jredir="${jdk.home.win32}" outdir="${sandbox.dir}"/>
+	</target>
+
 	<!-- ================================================================================= -->
 	<!--                             Release Generation Targets                            -->
 	<!-- ================================================================================= -->

--- a/codebase/profiles/system.properties.xml
+++ b/codebase/profiles/system.properties.xml
@@ -83,7 +83,7 @@
 	     for a particular profile.
 	-->
 	<generateCppCompilerVariables compilers="gcc4,gcc8,vc14,vc14_1,vc14_2,vc14_3"
-	                              architectures="amd64"
+	                              architectures="x86,amd64"
 	                              builds="debug,release"/>
 
 	<!-- =========================================================== -->

--- a/codebase/profiles/windows/hla13-32.xml
+++ b/codebase/profiles/windows/hla13-32.xml
@@ -1,0 +1,321 @@
+<?xml version="1.0"?>
+<!--
+                  Welcome to the Portico Build System
+
+       The Portico build system is an artefact-driven, modular, Ant
+       based system. The base framework is split up over a number of
+       different build files (base structure, macros, etc...) and is
+       designed to be extended rather than modified. The full system
+       is introduced and described in the online documentation:
+       
+       http://porticoproject.org/index.php?title=Building_Portico
+-->
+<project name="hla13-32">
+
+	<!-- ================================================================================= -->
+	<!--                                 General Settings                                  -->
+	<!-- ================================================================================= -->
+	<description>
+		Windows C++ build profile for HLA v1.3 Interface (32-bit)
+	</description>
+
+	<!-- ==== Basic Properties ==== -->
+	<!-- Get a reference to the JDK we want to use, falling back on the given default -->
+	<verifyJdk location="${jdk.home.win32}" arch="x86" requiredVersion="${java.compiler.target}"/>
+
+	<!--                                       -->
+	<!--                WARNING                -->
+	<!--                                       -->
+	<!--   This file uses properties declared  -->
+	<!--   in hla13.xml. Import it after that  -->
+	<!--   File has been imported.             -->
+
+	<!-- ==================================== -->
+	<!-- ==== HLA13 Interface Properties ==== -->
+	<!-- ==================================== -->
+	<!-- compiler properties -->
+	<!--<property name="compiler.args.debug"       value="/Zi /MDd /Od /EHsc /GR /W0"/>-->
+	<!--<property name="compiler.args.release"     value="/MD /Od /EHsc /GR /W0"/>-->
+	<!-- Sets property to value safe for visual studio build numbers: 1,1,1,1 -->
+	<!--<visualStudioBuildNumber property="product.version" value="${build.version}.${build.number}"/>-->
+
+	<!-- source -->
+	<!--<property name="hla13.src.dir"             location="${cpp.src.dir}/hla13/src"/>-->
+	<!--<property name="hla13.include.dir"         location="${cpp.src.dir}/hla13/include/hla13"/>-->
+	<!--<property name="hla13.test.src.dir"        location="${cpp.src.dir}/hla13/test"/>-->
+	<!--<property name="hla13.example.dir"         location="${cpp.src.dir}/hla13/example"/>-->
+
+	<!-- build -->
+	<property name="hla13-32.build.dir"           location="${build.dir}/cpp/win32/hla13"/>
+	<property name="hla13-32.complete.dir"        location="${hla13.build.dir}/complete"/>
+
+	<!-- ================================================================================= -->
+	<!--                                   Clean Targets                                   -->
+	<!-- ================================================================================= -->
+	<target name="clean">
+		<delete dir="${hla13-32.build.dir}"/>
+	</target>
+
+	<!-- ================================================================================= -->
+	<!--                                 Compile Targets                                   -->
+	<!-- ================================================================================= -->
+	<!-- extends on the main cpp compiling extension point declared externally -->
+	<extension-point name="hla13-32.compile"
+	                 extensionOf="cpp.compile"
+	                 description="Compile the full HLA v1.3 interface (32-bit)"/>
+
+	<!-- ================================================================= -->
+	<!--             Visual Studio 2017 (vc14_1) Compile Targets           -->
+	<!-- ================================================================= -->
+	<!-- The Visual Studio 2017 related extension points.
+	     We have one of these for each supported platform architecture so
+		 that we can compile all the targets for each arch as a group.
+	-->
+	<target name="compile.vc14_1" extensionOf="hla13-32.compile">
+		<compile-hla13-32 compiler="vc14_1" arch="x86" build="debug"/>
+		<compile-hla13-32 compiler="vc14_1" arch="x86" build="release"/>
+	</target>
+
+	<!-- ================================================================================= -->
+	<!--                                  Sandbox Targets                                  -->
+	<!-- ================================================================================= -->
+	<!-- 
+	     The main sandbox preparation target. This will aggregate together all the various
+	     required artefacts scattered around the build environment into the structure that
+	     should be present when installed on a users system (relative to the sandbox dir).
+	-->
+	<target name="sandbox" depends="java.sandbox,cpp.hla13-32.compile">
+		<!-- ======================= -->
+		<!-- Copy across the Headers -->
+		<!-- ======================= -->
+		<mkdir dir="${sandbox.dir}/include/hla13"/>
+		<copy todir="${sandbox.dir}/include/hla13">
+			<fileset dir="${hla13.include.dir}" includes="**/*"/>
+		</copy>
+
+		<!-- ========================= -->
+		<!-- Copy across the libraries -->
+		<!-- ========================= -->
+		<!-- Copy across the C++ libraries -->
+		<mkdir dir="${sandbox.lib.dir}"/>
+		<copy todir="${sandbox.lib.dir}">
+			<fileset dir="${hla13-32.complete.dir}" includes="**/*.lib,**/*.exp,**/*.pdb"/>
+		</copy>
+		<!-- Copy across the C++ dlls -->
+		<mkdir dir="${sandbox.bin.dir}"/>
+		<copy todir="${sandbox.bin.dir}">
+			<fileset dir="${hla13-32.complete.dir}" includes="**/*.dll"/>
+		</copy>
+
+		<!-- ================================= -->
+		<!-- Copy across the example federates -->
+		<!-- ================================= -->
+		<mkdir dir="${sandbox.examples.dir}/cpp/hla13"/>
+		<copy todir="${sandbox.examples.dir}/cpp/hla13">
+			<fileset dir="${hla13.example.dir}" includes="**/*"/>
+		</copy>
+	</target>
+	
+	<!-- ================================================================================= -->
+	<!--                             Release Generation Targets                            -->
+	<!-- ================================================================================= -->
+	<!-- 
+	     The parent release target. This will run a clean and then compile all code, run all
+	     tests, generate a sandbox and place all additional release artefacts in with it as
+		 preparation for release.
+	-->
+	<target name="hla13-32.release"
+	        depends="cpp.hla13-32.clean,cpp.hla13-32.sandbox"/>
+
+	<!-- ================================================================================= -->
+	<!--                            HLA v1.3 Helper Macros                                 -->
+	<!-- ================================================================================= -->
+	<!-- ================================================ -->
+	<!--               Macro: compile-hla13               -->
+	<!-- ================================================ -->
+	<!--
+		 This macro is a simple wrapper for msvc-hla13. It performs two main tasks:
+		   1. Checks to see whether the requested compiler/arch/build setting was requested
+		      in the cpp.profile and skips the build if it wasn't
+		   2. If it was requested, makes sure that the appropriate version of Visual Studio
+		      is installed. If it isn't, the compile  is skipped, unless this is a strict
+			  build, in which case the build will be failed
+	-->
+	<macrodef name="compile-hla13-32">
+		<!-- Attributes -->
+		<attribute name="compiler" description="vc14_2, vc14_1, vc14"/>
+		<attribute name="arch"     description="x86 or amd64"/>
+		<attribute name="build"    description="release or debug"/>
+
+		<sequential>
+			<!-- ========================== -->
+			<!-- 1. Check the build profile -->
+			<!-- ========================== -->
+			<!-- Only run this if it's in the requested build profile -->
+			<if><isset property="@{compiler}.@{arch}.@{build}"/>
+			<then>
+				<!-- ========================== -->
+				<!-- 2. Check for Visual Studio -->
+				<!-- ========================== -->
+				<!-- Make sure the requested version of Visual Studio is present on the system -->
+				<if><isVisualStudioPresent version="@{compiler}"/>
+					<then>
+						<echo message="[Compile] (HLA v1.3) @{compiler}.@{arch}.@{build}"/>
+						<msvc-hla13-32 compiler="@{compiler}" arch="@{arch}" build="@{build}"/>
+					</then>
+				<elseif><istrue value="${cpp.strict}"/>
+					<then>
+						<!-- Visual Studio NOT installed - strict build, fail out -->
+						<fail message="[Error] (HLA v1.3) @{compiler}.@{arch}.@{build}: @{compiler} is not installed"/>
+					</then>
+				</elseif>
+				<else>
+					<!-- This is not a strict build, just skip this compile -->
+					<echo message="[Skip] (HLA v1.3) @{compiler}.@{arch}.@{build} -- @{compiler} is not installed"/>
+				</else>
+				</if>
+			</then>
+			<else>
+				<echo message="[Skip] (HLA v1.3) @{compiler}.@{arch}.@{build} -- not requested"/>
+			</else>
+			</if>
+		</sequential>
+	</macrodef>
+
+	<!-- ================================================ -->
+	<!--                Macro: msvc-hla13                 -->
+	<!-- ================================================ -->
+	<!-- 
+	     The various C++ compiling commands have a lot in common. They share the same
+		 source and include base, the same preprocessor definitions, very similar library
+		 names and similar library dependencies. Despite being *very* similar, each of the
+		 builds requires something just a little bit different.
+		 
+		 This macro hides all the little details and give a target compiler, architecture
+		 and build type, generates the appropriate libraries (adusting library names,
+		 working directories, preprocessor definitions, compiler args, etc...)
+		 
+		 The output from running this macro will be the libRTI-NG and libFedTime
+		 libraries (names updated approrpiate for debug/release and 32/64-bit)
+		 dropped into ${hla13.complete.dir}.
+		 
+		 NOTE: This macro should always be wrapped in a <compile-hl13> task to ensure it
+		       only runs when it needs to.
+		 
+		 Usage:
+			* <msvc-hla13 compiler="vc10" arch="x86" build="debug"/>
+			
+		 Arguments:
+			* compiler: The compiler to use (vc14_2, vc14_1, vc10, vc9 or vc8)
+			* arch:     The platform architecture (x86 or amd64)
+			* build:    The build type (debug or release)
+	-->	 
+	<macrodef name="msvc-hla13-32" description="(HLA 1.3) Compile the RTI libraries">
+		<!-- Attributes -->
+		<attribute name="compiler" description="vc14_2, vc14_1, vc14"/>
+		<attribute name="arch"     description="x86 or amd64"/>
+		<attribute name="build"    description="release or debug"/>
+
+		<sequential>
+			<!-- Local properties used in the macro -->
+			<local name="_bitness"/>     <!-- appends "64" or "" to end of library name -->
+			<local name="_d"/>           <!-- appends "d" or "" to end of library name -->
+			<local name="_cargs"/>       <!-- compiler arguments -->
+			<local name="_largs"/>       <!-- linker arguments -->
+			<local name="_buildsymbol"/> <!-- adds "DEBUG" or "RELEASE" symbol definition -->
+			<local name="_jdkhome"/>     <!-- path to either 32 or 64-bit JDK -->
+
+			<!-- Are we building for 32-bit or 64-bit? -->
+			<if><equals arg1="@{arch}" arg2="amd64"/><then>
+				<property name="_bitness" value="_64"/>
+				<property name="_jdkhome" value="${jdk.home.win64}"/>
+			</then><else>
+				<property name="_bitness" value=""/>
+				<property name="_jdkhome" value="${jdk.home.win32}"/>
+			</else></if>
+
+			<!-- Is this a Debug or Release build? -->
+			<if><equals arg1="@{build}" arg2="debug"/><then>
+				<!-- Debug Build -->
+				<property name="_d"           value="d"/>
+				<property name="_cargs"       value="${compiler.args.debug}"/>
+				<property name="_largs"       value="/DEBUG"/>
+				<property name="_buildsymbol" value="DEBUG"/>
+			</then><else>
+				<!-- Release Build -->
+				<property name="_d"           value=""/>
+				<property name="_cargs"       value="${compiler.args.release}"/>
+				<property name="_largs"       value=""/>
+				<property name="_buildsymbol" value="RELEASE"/>
+			</else></if>
+
+			<!-- ========================== -->
+			<!-- Do the library compilation -->
+			<!-- ========================== -->
+			<!-- library: libFedTime -->
+			<echo message="(HLA v1.3) Building libFedTime${_bitness}${_d} (@{compiler}-@{build} @{arch})"/>
+			<cpptask outfile="libFedTime${_bitness}${_d}"
+					 workdir="${hla13.build.dir}/@{compiler}/@{arch}/@{build}"
+					 outdir="${hla13.complete.dir}/@{compiler}"
+					 type="shared"
+					 arch="@{arch}"
+					 compiler="@{compiler}"
+					 compilerArgs="${_cargs}"
+					 linkerArgs="${_largs}"
+					 threadCount="auto">
+				<fileset dir="${hla13.src.dir}">
+					<include name="**/*.rc"/>
+					<include name="time/RTIfedTime.cpp"/>
+					<include name="time/FedTime.cpp"/>
+					<include name="time/FedTimeFactory.cpp"/>
+					<include name="types/Exception.cpp"/>
+				</fileset>
+				<includepath path="${hla13.include.dir}"/>
+				<includepath path="${hla13.src.dir}"/>
+				<includepath path="${jdk.home.win32}/include;${jdk.home.win32}/include/win32"/>
+				<define name="RTI_USES_STD_FSTREAM"/>
+				<define name="BUILDING_RTI"/>
+				<define name="BUILDING_FEDTIME"/>
+				<define name="${_buildsymbol}"/> <!-- DEBUG or RELEASE -->
+				<define name="PORTICO_VERSION=${build.version}"/>
+				<define name="PORTICO_BUILD_NUMBER=${build.number}"/>
+				<define name="PRODUCT_VERSION=${product.version}"/>       <!-- for DLL -->
+				<define name="PRODUCT_INTERNAL_NAME=libFedTime${_bitness}${_d}"/>  <!-- for DLL -->
+				<library path="${_jdkhome}/lib" libs="jvm"/>
+			</cpptask>
+
+			<echo message="(HLA v1.3) Building libRTI-NG${_bitness}${_d} (@{compiler}-@{build} @{arch})"/>
+			<cpptask outfile="libRTI-NG${_bitness}${_d}"
+					 workdir="${hla13.build.dir}/@{compiler}/@{arch}/@{build}"
+					 outdir="${hla13.complete.dir}/@{compiler}"
+					 type="shared"
+					 arch="@{arch}"
+					 compiler="@{compiler}"
+					 compilerArgs="${_cargs}"
+					 linkerArgs="${_largs}"
+					 threadCount="auto">
+				<fileset dir="${hla13.src.dir}">
+					<include name="**/*.cpp"/>
+					<include name="**/*.rc"/>
+					<exclude name="time/RTIfedTime.cpp"/>
+					<exclude name="time/FedTime.cpp"/>
+					<exclude name="time/FedTimeFactory.cpp"/>
+				</fileset>
+				<includepath path="${hla13.include.dir}"/>
+				<includepath path="${hla13.src.dir}"/>
+				<includepath path="${jdk.home.win32}/include;${jdk.home.win32}/include/win32"/>
+				<define name="RTI_USES_STD_FSTREAM"/>
+				<define name="BUILDING_RTI"/>
+				<define name="${_buildsymbol}"/> <!-- DEBUG or RELEASE -->
+				<define name="PORTICO_VERSION=${build.version}"/>
+				<define name="PORTICO_BUILD_NUMBER=${build.number}"/>
+				<define name="PRODUCT_VERSION=${product.version}"/>              <!-- for DLL -->
+				<define name="PRODUCT_INTERNAL_NAME=libRTI-NG${_bitness}${_d}"/> <!-- for DLL -->
+				<library path="${_jdkhome}/lib" libs="jvm"/>
+				<library path="${hla13.complete.dir}/@{compiler}"
+						 libs="libFedTime${_bitness}${_d}"/>
+			</cpptask>
+		</sequential>
+	</macrodef>
+
+</project>

--- a/codebase/profiles/windows/ieee1516e-32.xml
+++ b/codebase/profiles/windows/ieee1516e-32.xml
@@ -1,0 +1,329 @@
+<?xml version="1.0"?>
+<!--
+                  Welcome to the Portico Build System
+
+       The Portico build system is an artefact-driven, modular, Ant
+       based system. The base framework is split up over a number of
+       different build files (base structure, macros, etc...) and is
+       designed to be extended rather than modified. The full system
+       is introduced and described in the online documentation:
+       
+       http://porticoproject.org/index.php?title=Building_Portico
+-->
+<project name="ieee1516e-32">
+
+	<!-- ================================================================================= -->
+	<!--                                 General Settings                                  -->
+	<!-- ================================================================================= -->
+	<description>
+		Windows C++ build profile for IEEE-1516 (2010) Interface [HLA Evolved] (32-bit)
+	</description>
+
+	<!-- ==== Basic Properties ==== -->
+	<!-- Verify that we have an appropriate JDK to build against -->
+	<verifyJdk location="${jdk.home.win32}" arch="x86" requiredVersion="${java.compiler.target}"/>
+
+	<!-- ================================================ -->
+	<!-- ==== IEEE-1516e (2010) Interface Properties ==== -->
+	<!-- ================================================ -->
+	<!-- compiler properties -->
+	<!--<property name="compiler.args.debug"       value="/Zi /MDd /Od /EHsc /GR /W0"/>-->
+	<!--<property name="compiler.args.release"     value="/MD /Od /EHsc /GR /W0"/>-->
+	<!-- Sets property to value safe for visual studio build numbers: 1,1,1,1 -->
+
+	<visualStudioBuildNumber property="product.version" value="${build.version}.${build.number}"/>
+
+	<!-- source -->
+	<!--<property name="ieee1516e.src.dir"         location="${cpp.src.dir}/ieee1516e/src"/>-->
+	<!--<property name="ieee1516e.include.dir"     location="${cpp.src.dir}/ieee1516e/include"/>-->
+	<!--<property name="ieee1516e.example.dir"     location="${cpp.src.dir}/ieee1516e/example"/>-->
+
+	<!-- build -->
+	<property name="ieee1516e-32.build.dir"       location="${build.dir}/cpp/win32/ieee1516e"/>
+	<property name="ieee1516e-32.complete.dir"    location="${ieee1516e.build.dir}/complete"/>
+
+	<!-- ================================================================================= -->
+	<!--                                   Clean Targets                                   -->
+	<!-- ================================================================================= -->
+	<target name="clean" extensionOf="cpp.clean">
+		<delete dir="${ieee1516e-32.build.dir}"/>
+	</target>
+
+	<!-- ================================================================================= -->
+	<!--                                 Compile Targets                                   -->
+	<!-- ================================================================================= -->
+	<!-- extends on the main cpp compiling extension point declared externally -->
+	<extension-point name="ieee1516e-32.compile"
+	                 extensionOf="cpp.compile"
+	                 description="Compile the full IEEE-1516e interface (32-bit)"/>
+	
+	<!-- ================================================================= -->
+	<!--            Visual Studio 2017 (vc14_1) Compile Targets            -->
+	<!-- ================================================================= -->
+	<!-- The Visual Studio 2017 related extension points.
+	     We have one of these for each supported platform architecture so
+		 that we can compile all the targets for each arch as a group.
+	-->
+	<target name="compile.vc14_1" extensionOf="ieee1516e-32.compile">
+		<compile-ieee1516e-32 compiler="vc14_1" arch="x86" build="debug"/>
+		<compile-ieee1516e-32 compiler="vc14_1" arch="x86" build="release"/>
+	</target>
+
+	<!-- ==================================== -->
+	<!--      IEEE-1516e Example Federate     -->
+	<!-- ==================================== -->
+	<!-- Compiles the 1516e example federate. Doesn't do much except
+	     assure that we can actually compile and link it to Portico.
+		 Only validates this with the latest supported compiler. -->
+	<target name="example.compile.amd64" depends="compile.vc14_1" if="vc14_1.x86.debug">
+		<cpptask outfile="ieee1516e-example"
+		         workdir="${ieee1516e-32.build.dir}/ieee1516e-example"
+		         type="executable"
+				 compiler="vc14_1"
+		         compilerArgs="/Zi /Od /EHsc /GR /MTd">
+			<fileset dir="${ieee1516e.example.dir}" includes="**/*.cpp"/>
+			<includepath path="${ieee1516e.include.dir}"/>
+			<define name="DEBUG"/>
+			<library path="${ieee1516e-32.complete.dir}/vc14_1" libs="rti1516ed,fedtime1516ed"/>
+			<library path="${jdk.home.win32}/lib" libs="jvm"/>
+		</cpptask>
+	</target>
+
+	<!-- ================================================================================= -->
+	<!--                                  Sandbox Targets                                  -->
+	<!-- ================================================================================= -->
+	<!-- 
+	     The main sandbox preparation target. This will aggregate together all the various
+	     required artefacts scattered around the build environment into the structure that
+	     should be present when installed on a users system (relative to the sandbox dir).
+	-->
+	<target name="sandbox" depends="java.sandbox,cpp.ieee1516e-32.compile" if="build.release.32">
+		<!-- ======================= -->
+		<!-- Copy across the Headers -->
+		<!-- ======================= -->
+		<mkdir dir="${sandbox.dir}/include/ieee1516e"/>
+		<copy todir="${sandbox.dir}/include/ieee1516e">
+			<fileset dir="${ieee1516e.include.dir}" includes="**/*"/>
+		</copy>
+
+		<!-- ========================= -->
+		<!-- Copy across the libraries -->
+		<!-- ========================= -->
+		<!-- Copy across the C++ libraries -->
+		<mkdir dir="${sandbox.lib.dir}"/>
+		<copy todir="${sandbox.lib.dir}">
+			<fileset dir="${ieee1516e-32.complete.dir}" includes="**/*.lib,**/*.exp,**/*.pdb"/>
+		</copy>
+		<!-- Copy across the C++ dlls -->
+		<mkdir dir="${sandbox.bin.dir}"/>
+		<copy todir="${sandbox.bin.dir}">
+			<fileset dir="${ieee1516e-32.complete.dir}" includes="**/*.dll"/>
+		</copy>
+
+		<!-- ================================= -->
+		<!-- Copy across the example federates -->
+		<!-- ================================= -->
+		<mkdir dir="${sandbox.examples.dir}/cpp/ieee1516e"/>
+		<copy todir="${sandbox.examples.dir}/cpp/ieee1516e">
+			<fileset dir="${ieee1516e.example.dir}" includes="**/*"/>
+		</copy>
+	</target>
+	
+	<!-- ================================================================================= -->
+	<!--                             Release Generation Targets                            -->
+	<!-- ================================================================================= -->
+	<!-- 
+	     The parent release target. This will run a clean and then compile all code, run all
+	     tests, generate a sandbox and place all additional release artefacts in with it as
+		 preparation for release.
+	-->
+	<target name="release"
+	        depends="clean,sandbox"/>
+
+	<!-- ================================================================================= -->
+	<!--                           IEEE-1516e Helper Macros                                -->
+	<!-- ================================================================================= -->
+	<!-- ================================================ -->
+	<!--               Macro: compile-hla13               -->
+	<!-- ================================================ -->
+	<!--
+		 This macro is a simple wrapper for msvc-ieee1516. It performs two main tasks:
+		   1. Checks to see whether the requested compiler/arch/build setting was requested
+		      in the cpp.profile and skips the build if it wasn't
+		   2. If it was requested, makes sure that the appropriate version of Visual Studio
+		      is installed. If it isn't, the compile  is skipped, unless this is a strict
+			  build, in which case the build will be failed
+	-->
+	<macrodef name="compile-ieee1516e-32">
+		<!-- Attributes -->
+		<attribute name="compiler" description="vc14_3, vc14_2, vc14_1"/>
+		<attribute name="arch"     description="amd64"/>
+		<attribute name="build"    description="release or debug"/>
+
+		<sequential>
+			<!-- ========================== -->
+			<!-- 1. Check the build profile -->
+			<!-- ========================== -->
+			<!-- Only run this if it's in the requested build profile -->
+			<if><isset property="@{compiler}.@{arch}.@{build}"/>
+			<then>
+				<!-- ========================== -->
+				<!-- 2. Check for Visual Studio -->
+				<!-- ========================== -->
+				<!-- Make sure the requested version of Visual Studio is present on the system -->
+				<if><isVisualStudioPresent version="@{compiler}"/>
+					<then>
+						<echo message="[Compile] (IEEE-1516e) @{compiler}.@{arch}.@{build}"/>
+						<msvc-ieee1516e-32 compiler="@{compiler}" arch="@{arch}" build="@{build}"/>
+					</then>
+				<elseif><istrue value="${cpp.strict}"/>
+					<then>
+						<!-- Visual Studio NOT installed - strict build, fail out -->
+						<fail message="[Error] (IEEE-1516e) @{compiler}.@{arch}.@{build}: @{compiler} is not installed"/>
+					</then>
+				</elseif>
+				<else>
+					<!-- This is not a strict build, just skip this compile -->
+					<echo message="[Skip] (IEEE-1516e) @{compiler}.@{arch}.@{build} -- @{compiler} is not installed"/>
+				</else>
+				</if>
+			</then>
+			<else>
+				<echo message="[Skip] (IEEE-1516e) @{compiler}.@{arch}.@{build} -- not requested"/>
+			</else>
+			</if>
+		</sequential>
+	</macrodef>
+
+	<!-- ================================================ -->
+	<!--               Macro: msvc-ieee1516               -->
+	<!-- ================================================ -->
+	<!-- 
+	     The various C++ compiling commands have a lot in common. They share the same
+		 source and include base, the same preprocessor definitions, very similar library
+		 names and similar library dependencies. Despite being *very* similar, each of the
+		 builds requires something just a little bit different.
+		 
+		 This macro hides all the little details and give a target compiler, architecture
+		 and build type, generates the appropriate libraries (adusting library names,
+		 working directories, preprocessor definitions, compiler args, etc...)
+		 
+		 The output from running this macro will be the libRTI-NG and libFedTime
+		 libraries (names updated approrpiate for debug/release and 32/64-bit)
+		 dropped into ${ieee1516e.complete.dir}.
+		 
+		 NOTE: This macro should always be wrapped in a <compile-ieee1516e> task to ensure it
+		       only runs when it needs to.
+		 
+		 Usage:
+			* <msvc-ieee1516 compiler="vc10" arch="x86" build="debug"/>
+			
+		 Arguments:
+			* compiler: The compiler to use (vc14_3, vc14_2, vc14_1)
+			* arch:     The platform architecture (amd64)
+			* build:    The build type (debug or release)
+	-->	 
+	<macrodef name="msvc-ieee1516e-32" description="(IEEE-1516e) Compile the RTI libraries">
+		<!-- Attributes -->
+		<attribute name="compiler" description="vc14_3, vc14_2, vc14_1"/>
+		<attribute name="arch"     description="amd64"/>
+		<attribute name="build"    description="release or debug"/>
+
+		<sequential>
+			<!-- Local properties used in the macro -->
+			<local name="_bitness"/>     <!-- appends "64" or "" to end of library name -->
+			<local name="_d"/>           <!-- appends "d" or "" to end of library name -->
+			<local name="_cargs"/>       <!-- compiler arguments -->
+			<local name="_largs"/>       <!-- linker arguments -->
+			<local name="_buildsymbol"/> <!-- adds "DEBUG" or "RELEASE" symbol definition -->
+			<local name="_jdkhome"/>     <!-- path to either 32 or 64-bit JDK -->
+
+			<!-- Are we building for 32-bit or 64-bit? -->
+			<if><equals arg1="@{arch}" arg2="amd64"/><then>
+				<property name="_bitness" value="64"/>
+				<property name="_jdkhome" value="${jdk.home.win64}"/>
+			</then><else>
+				<property name="_bitness" value=""/>
+				<property name="_jdkhome" value="${jdk.home.win32}"/>
+			</else></if>
+
+			<!-- Is this a Debug or Release build? -->
+			<if><equals arg1="@{build}" arg2="debug"/><then>
+				<!-- Debug Build -->
+				<property name="_d"           value="d"/>
+				<property name="_cargs"       value="${compiler.args.debug}"/>
+				<property name="_largs"       value="/DEBUG"/>
+				<property name="_buildsymbol" value="DEBUG"/>
+			</then><else>
+				<!-- Release Build -->
+				<property name="_d"           value=""/>
+				<property name="_cargs"       value="${compiler.args.release}"/>
+				<property name="_largs"       value=""/>
+				<property name="_buildsymbol" value="RELEASE"/>
+			</else></if>
+
+			<!-- ========================== -->
+			<!-- Do the library compilation -->
+			<!-- ========================== -->
+			<!-- Build the main DLL -->
+			<echo message="(IEEE-1516e) Building librti1516e${_bitness}${_d} (@{compiler}-@{build} @{arch})"/>
+			<cpptask outfile="librti1516e${_bitness}${_d}"
+			         workdir="${ieee1516e.build.dir}/@{compiler}/@{arch}/@{build}"
+					 outdir="${ieee1516e.complete.dir}/@{compiler}"
+			         type="shared"
+			         arch="@{arch}"
+			         compiler="@{compiler}"
+			         compilerArgs="${_cargs}"
+			         linkerArgs="${_largs}"
+			         threadCount="auto">
+				<fileset dir="${ieee1516e.src.dir}">
+					<include name="**/*.cpp"/>
+					<include name="**/*.rc"/>
+					<exclude name="types/time/LogicalTimeFactoryFactory.cpp"/>
+				</fileset>
+				<includepath path="${ieee1516e.include.dir}"/>
+				<includepath path="${ieee1516e.src.dir}"/>
+				<includepath path="${jdk.home.win32}/include;${jdk.home.win32}/include/win32"/>
+				<define name="BUILDING_RTI"/>
+				<define name="RTI_DISABLE_WARNINGS"/>
+				<define name="${_buildsymbol}"/> <!-- DEBUG or RELEASE -->
+				<define name="PORTICO_VERSION=${build.version}"/>
+				<define name="PORTICO_NUMBER=${build.number}"/>
+				<define name="PRODUCT_VERSION=${product.version}"/>                <!-- for DLL -->
+				<define name="PRODUCT_INTERNAL_NAME=librti1516e${_bitness}${_d}"/> <!-- for DLL -->
+				<library path="${_jdkhome}/lib" libs="jvm"/>
+			</cpptask>			
+
+			<!-- library: libfedtime -->
+			<echo message="(IEEE-1516e) Building libfedtime1516e${_bitness}${_d} (@{compiler}-@{build} @{arch})"/>
+			<cpptask outfile="libfedtime1516e${_bitness}${_d}"
+			         workdir="${ieee1516e.build.dir}/@{compiler}/@{arch}/@{build}"
+					 outdir="${ieee1516e.complete.dir}/@{compiler}"
+			         type="shared"
+			         arch="@{arch}"
+			         compiler="@{compiler}"
+			         compilerArgs="${_cargs}"
+			         linkerArgs="${_largs}"
+			         threadCount="auto">
+				<fileset dir="${ieee1516e.src.dir}">
+					<include name="types/time/LogicalTimeFactoryFactory.cpp"/>
+					<include name="**/*.rc"/>
+				</fileset>
+				<includepath path="${ieee1516e.include.dir}"/>
+				<includepath path="${ieee1516e.src.dir}"/>
+				<includepath path="${jdk.home.win32}/include;${jdk.home.win32}/include/win32"/>
+				<define name="BUILDING_FEDTIME"/>
+				<define name="RTI_DISABLE_WARNINGS"/>
+				<define name="${_buildsymbol}"/> <!-- DEBUG or RELEASE -->
+				<define name="PORTICO_VERSION=${build.version}"/>
+				<define name="PORTICO_BUILD_NUMBER=${build.number}"/>
+				<define name="PRODUCT_VERSION=${product.version}"/>                    <!-- for DLL -->
+				<define name="PRODUCT_INTERNAL_NAME=libfedtime1516e${_bitness}${_d}"/> <!-- for DLL -->
+				<library path="${_jdkhome}/lib" libs="jvm"/>
+				<library path="${ieee1516e.complete.dir}/@{compiler}"
+				         libs="rti1516e${_bitness}${_d}"/>
+			</cpptask>
+		</sequential>
+	</macrodef>
+
+</project>

--- a/codebase/profiles/windows/installer-32.xml
+++ b/codebase/profiles/windows/installer-32.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0"?>
+<!--
+                  Welcome to the Portico Build System
+
+       The Portico build system is an artefact-driven, modular, Ant
+       based system. The base framework is split up over a number of
+       different build files (base structure, macros, etc...) and is
+       designed to be extended rather than modified. The full system
+       is introduced and described in the online documentation:
+       
+       http://porticoproject.org/index.php?title=Building_Portico
+-->
+<project name="installer-32">
+
+	<!-- ================================================================================= -->
+	<!--                                 General Settings                                  -->
+	<!-- ================================================================================= -->
+	<description>
+		Windows installer generation (32-bit).
+	</description>
+
+	<!-- NSIS Installer Properties -->
+	<property name="nsis.resources.dir"    location="${resources.dir}/installers/windows/nsis"/>
+
+	<!-- ================================================================================= -->
+	<!--                           Installer Preparation Targets                           -->
+	<!-- ================================================================================= -->
+	<!-- Prepare the build directory -->
+	<target name="prep-32" depends="java.sandbox.jre32">
+		<!-- copy the installer resources into the sandbox -->
+		<copy todir="${sandbox.dir}">
+			<fileset dir="${nsis.resources.dir}" includes="*.url"/> 
+		</copy>
+	</target>
+
+	<!-- ================================================================================= -->
+	<!--                             Installer Creation Targets                            -->
+	<!-- ================================================================================= -->
+
+	<!--                                     -->
+	<!-- Windows 64-bit Installer Generation -->
+	<!--                                     -->
+	<target name="nsis.win32" depends="prep-32">
+		<!-- Verify we have a JRE we can bundle -->
+		<verifyJdk location="${jdk.home.win32}" arch="x86" requiredVersion="${java.compiler.target}"/>
+
+		<!-- run the NSIS script for the installer -->
+		<echo>Creating Windows 32-bit Installer</echo>
+		<nsis-installer script="${nsis.resources.dir}/installer-win32.nsi">
+			<define name="DIST_NAME"    value="${build.shortname}"/> <!-- start of file name     -->
+			<define name="OUTDIR"       value="${dist.dir}"/>        <!-- put installer here     -->
+			<define name="VERSION"      value="${build.version}"/>   <!-- e.g. "2.0.0"           -->
+			<define name="BUILD_NUMBER" value="${build.number}"/>    <!-- shown in file details  -->
+			<define name="LICENSE"      value="${license}"/>         <!-- shown during install   -->
+			<define name="SANDBOX"      value="${sandbox.dir}"/>     <!-- contents of the app    -->
+			<define name="JREPATH"      value="${sandbox.dir}\jre"/> <!-- jre to bundle -->
+		</nsis-installer>
+	</target>
+
+	<!-- ================================================================================= -->
+	<!--                             Zip-File Creation Targets                             -->
+	<!-- ================================================================================= -->
+	<!-- These are only run on command - they're not tied into the broader build system -->
+
+	<!--                                    -->
+	<!-- Windows 64-bit Zip File Generation -->
+	<!--                                    -->
+	<target name="zip.win32" depends="prep-32">
+		<!-- Verify we have a JRE we can bundle -->
+		<verifyJdk location="jdk.home.win32" arch="x86" requiredVersion="${java.compiler.target}"/>
+
+		<!-- generate the tarball with the sandbox and the JRE in it -->
+		<zip destfile="${dist.dir}/${dist.name}-win32.zip">
+			<zipfileset dir="${sandbox.dir}"
+			            includes="**/*"
+			            excludes="lib/**/*,bin/**/*"
+			            prefix="${dist.name}"/>
+			<zipfileset dir="${sandbox.dir}"
+			            includes="lib/*.jar,lib/**/*,bin/**/*"
+			            prefix="${dist.name}"/>
+			<zipfileset dir="${sandbox.dir}/jre"
+			            includes="**/*"
+			            prefix="${dist.name}/jre"/>
+		</zip>
+	</target>
+
+</project>

--- a/codebase/src/cpp/hla13/example/win32-vc14_1.bat
+++ b/codebase/src/cpp/hla13/example/win32-vc14_1.bat
@@ -1,0 +1,83 @@
+@echo off
+
+rem # Paths to the VS initialization batch files
+set VS_IDE_FILE="C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvarsall.bat"
+set VS_BUILDTOOLS_FILE="C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat"
+
+rem ##########################################################################
+rem Please consult the README file to learn more about this example federate #
+rem ##########################################################################
+
+rem ################################
+rem # check command line arguments #
+rem ################################
+:checkargs
+if "%1" == "" goto usage
+
+rem ###################
+rem # Set up RTI_HOME #
+rem ###################
+:rtihome
+cd ..\..\..
+set RTI_HOME=%CD%
+cd examples\cpp\hla13
+echo RTI_HOME environment variable is set to %RTI_HOME%
+goto run
+
+:run
+if "%1" == "clean" goto clean
+if "%1" == "compile" goto compile
+if "%1" == "execute" goto execute
+
+rem ############################################
+rem ### (target) clean #########################
+rem ############################################
+:clean
+echo Deleting example federate executable and left over logs
+del *.obj
+del main.exe
+rd /S /Q logs
+goto finish
+
+############################################
+### (target) compile #######################
+############################################
+:compile
+echo Compiling example federate
+
+rem Check for Visual Studio IDE
+if exist %VS_IDE_FILE% (
+    echo Found Visual Studio 2017 Professional
+    call %VS_IDE_FILE% x86
+    goto runcompiler
+)
+
+rem Check for Visual Studio Build Tools
+if exist %VS_BUILDTOOLS_FILE% (
+    echo Found Visual Studio 2017 Build Tools
+    call %VS_BUILDTOOLS_FILE% x86
+    goto runcompiler
+)
+
+echo Visual Studio compiler not found. Need either Visual Studio, or the Build Tools installed
+goto finish
+
+:runcompiler
+cl /I"%RTI_HOME%\include\hla13" /DRTI_USES_STD_FSTREAM /EHsc main.cpp ExampleCPPFederate.cpp ExampleFedAmb.cpp "%RTI_HOME%\lib\vc14_1\libRTI-NG.lib" "%RTI_HOME%\lib\vc14_1\libFedTime.lib"
+goto finish
+
+############################################
+### (target) execute #######################
+############################################
+:execute
+SHIFT
+set PATH=%RTI_HOME%\jre\bin\server;%RTI_HOME%\bin\vc14_1;%PATH%
+main %1 %2 %3 %4 %5 %6 %7 %8 %9
+goto finish
+
+
+:usage
+echo usage: win64-vc14_1.bat [compile] [clean] [execute [federate-name]]
+echo  note: Script assumes you have Visual Studio, or the Visual Studio Build Tools installed in default location.
+
+:finish

--- a/codebase/src/cpp/ieee1516e/example/win32-vc14_1.bat
+++ b/codebase/src/cpp/ieee1516e/example/win32-vc14_1.bat
@@ -1,0 +1,82 @@
+@echo off
+
+rem # Paths to the VS initialization batch files
+set VS_IDE_FILE="C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\VC\Auxiliary\Build\vcvarsall.bat"
+set VS_BUILDTOOLS_FILE="C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat"
+
+rem ##########################################################################
+rem Please consult the README file to learn more about this example federate #
+rem ##########################################################################
+
+rem ################################
+rem # check command line arguments #
+rem ################################
+:checkargs
+if "%1" == "" goto usage
+
+rem ###################
+rem # Set up RTI_HOME #
+rem ###################
+:rtihome
+cd ..\..\..
+set RTI_HOME=%CD%
+cd examples\cpp\ieee1516e
+echo RTI_HOME environment variable is set to %RTI_HOME%
+goto run
+
+:run
+if "%1" == "clean" goto clean
+if "%1" == "compile" goto compile
+if "%1" == "execute" goto execute
+
+rem ############################################
+rem ### (target) clean #########################
+rem ############################################
+:clean
+echo Deleting example federate executable and left over logs
+del *.obj
+del main.exe
+rd /S /Q logs
+goto finish
+
+############################################
+### (target) compile #######################
+############################################
+:compile
+echo Compiling example federate
+
+rem Check for Visual Studio IDE
+if exist %VS_IDE_FILE% (
+    echo Found Visual Studio 2017 Professional
+    call %VS_IDE_FILE% x86
+    goto runcompiler
+)
+
+rem Check for Visual Studio Build Tools
+if exist %VS_BUILDTOOLS_FILE% (
+    echo Found Visual Studio 2017 Build Tools
+    call %VS_BUILDTOOLS_FILE% x86
+    goto runcompiler
+)
+
+echo Visual Studio compiler not found. Need either Visual Studio, or the Build Tools installed
+goto finish
+
+:runcompiler
+cl /I"%RTI_HOME%\include\ieee1516e" /DRTI_USES_STD_FSTREAM /EHsc main.cpp ExampleCPPFederate.cpp ExampleFedAmb.cpp "%RTI_HOME%\lib\vc14_1\librti1516e.lib" "%RTI_HOME%\lib\vc14_1\libfedtime1516e.lib"
+goto finish
+
+############################################
+### (target) execute #######################
+############################################
+:execute
+SHIFT
+set PATH=%RTI_HOME%\jre\bin\server;%RTI_HOME%\bin\vc14_1;%PATH%
+main %1 %2 %3 %4 %5 %6 %7 %8 %9
+goto finish
+
+
+:usage
+echo usage: win32-vc10.bat [compile] [clean] [execute [federate-name]]
+
+:finish


### PR DESCRIPTION
- Adds targets to compile 14_1 x86 builds
- Adds batch scripts for 32-bit support for example federates
- Adds packaging support for 32-bit jre
- Adds installer generation for 32-bit installer