### PR TITLE
Fix cross-heap free of userSuppliedTag in JniUtils::toTag

### DIFF
--- a/codebase/src/cpp/ieee1516e/src/jni/JniUtils.cpp
+++ b/codebase/src/cpp/ieee1516e/src/jni/JniUtils.cpp
@@ -890,8 +890,7 @@ VariableLengthData JniUtils::toTag( JNIEnv *jnienv, jbyteArray jtag )
 	// convert the tag
 	//   we assume that there is no null terminator
 	jsize size = jnienv->GetArrayLength( jtag );
-	jbyte *buffer = new jbyte[size];
-	jnienv->GetByteArrayElements( jtag, NULL );
+	jbyte *buffer = jnienv->GetByteArrayElements( jtag, NULL );
 	VariableLengthData data( (void*)buffer, size );
 	jnienv->ReleaseByteArrayElements( jtag, buffer, JNI_ABORT );
 	return data;


### PR DESCRIPTION
The previous implementation allocated a buffer with `new jbyte[size]` (RTI DLL heap) and then discarded the pointer returned by GetByteArrayElements, passing the unrelated `new[]` pointer to ReleaseByteArrayElements instead. This caused the JVM to free a block from the wrong heap, resulting in STATUS_HEAP_CORRUPTION (0xC0000374) on every reflectAttributeValues/receiveInteraction/removeObjectInstance callback that carried a non-null userSuppliedTag.

Additionally, because GetByteArrayElements' return value was thrown away, buffer held uninitialized memory and the received tag bytes were never actually read.

Fix: capture the pointer GetByteArrayElements returns, build VariableLengthData from that pointer, then release that same pointer with JNI_ABORT. This matches the already-correct pattern used by toAttributeValueMap/toParameterValueMap in the same file.